### PR TITLE
feat(cache): migrate from unstable_cache to use cache directive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ User Input → parseProject() → analyze() → fetchRepoMetrics() → calculate
 3. `src/lib/github/` - Fetches metrics from GitHub API via Octokit (GraphQL + REST)
 4. `src/lib/maintenance.ts` - Computes maintenance score (0-100) and category
 5. `src/db/schema.ts` - Single `assessments` table with upsert on conflict
-6. `src/db/queries.ts` - Cached queries with `unstable_cache` + React `cache()` for request deduplication
+6. `src/db/queries.ts` - Cached queries with `"use cache"` + React `cache()` for request deduplication
 
 ### Key Modules
 
@@ -100,7 +100,7 @@ User Input → parseProject() → analyze() → fetchRepoMetrics() → calculate
 | `src/lib/maintenance.ts` | Maintenance scoring algorithm. Categories: healthy (70+), moderate (45-69), at-risk (20-44), unmaintained (0-19). |
 | `src/lib/maintenance-config.ts` | Centralized config for scoring weights, thresholds, and maturity tiers. All tunable values in one place. |
 | `src/lib/github/` | GitHub API client (modular). `metrics.ts` for GraphQL, `activity.ts` for REST commit stats, `rate-limit.ts` for parsing. |
-| `src/db/queries.ts` | Database queries with caching: `cache()` for request-level deduplication, `unstable_cache` for persistent project cache. |
+| `src/db/queries.ts` | Database queries with caching: `cache()` for request-level deduplication, `"use cache"` for persistent project cache. |
 | `src/lib/logger.ts` | Generic structured logger for external API calls with duration and rate limit tracking. |
 
 ### Directory Structure
@@ -121,10 +121,10 @@ User Input → parseProject() → analyze() → fetchRepoMetrics() → calculate
 ## Code Patterns
 
 ### Caching Strategy
-- `unstable_cache` with tags for persistent project cache (24hr TTL)
+- `"use cache"` directive with tags for persistent project cache (7-day TTL)
 - React `cache()` wrapper for request-level deduplication
-- Tag-based invalidation: `project:{owner}/{project}` for specific projects
-- Recent assessments query has no persistent cache (always fresh from DB)
+- Tag-based invalidation: `project:{owner}/{project}` for specific projects, `recent-assessments` for homepage list
+- Recent assessments uses `"use cache"` with 5-minute TTL, invalidated on new analysis
 
 ## Code Conventions
 
@@ -164,7 +164,7 @@ Tests in `*.test.ts` files alongside source. Run with `bun run test`.
 - Default to server components - only add `"use client"` when hooks are needed
 - Fetch data in server components, not in client components
 - Use server actions for mutations, not API routes
-- Leverage caching (`unstable_cache`, React `cache()`) aggressively
+- Leverage caching (`"use cache"`, React `cache()`) aggressively
 
 **Code quality:**
 - Assume dev server is already running

--- a/next.config.ts
+++ b/next.config.ts
@@ -44,6 +44,7 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
+  cacheComponents: true,
   reactCompiler: true,
   images: {
     remotePatterns: [

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "bun --bun next dev",
-    "build": "bun --bun next build",
-    "start": "bun --bun next start",
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
     "check-types": "tsc --noEmit",
     "lint": "biome check --write",
     "format": "biome format --write",

--- a/src/actions/analyze.ts
+++ b/src/actions/analyze.ts
@@ -12,7 +12,7 @@ import { fetchFreshAssessment } from "@/lib/assessment";
 /**
  * Server action: Analyze a GitHub repository with freshness checking.
  *
- * Returns cached data if fresh (<24h), otherwise fetches from GitHub API.
+ * Returns cached data if fresh (<7 days), otherwise fetches from GitHub API.
  * Called from homepage search form - blocks until complete, then navigates.
  *
  * @param owner - Repository owner (username or organization)
@@ -37,8 +37,9 @@ export async function analyze(
   // Stale or missing - fetch fresh from GitHub
   const result = await fetchFreshAssessment(owner, project);
 
-  // Invalidate cached data for this specific repo
+  // Invalidate cached data for this specific repo and recent assessments list
   updateTag(getProjectTag(owner, project));
+  updateTag("recent-assessments");
 
   return result;
 }

--- a/src/app/p/[owner]/[project]/_components/chart-skeletons.tsx
+++ b/src/app/p/[owner]/[project]/_components/chart-skeletons.tsx
@@ -1,3 +1,4 @@
+import { Container } from "@/components/container";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 
 export function CommitChartSkeleton() {
@@ -31,5 +32,62 @@ export function ScoreSkeleton() {
         <div className="h-3 w-32 bg-muted animate-pulse rounded" />
       </CardContent>
     </Card>
+  );
+}
+
+export function ProjectPageSkeleton() {
+  return (
+    <>
+      {/* Header skeleton */}
+      <Container>
+        <div className="flex flex-col sm:flex-row sm:items-start gap-6">
+          <div className="flex items-start gap-4 flex-1 min-w-0">
+            <div className="h-16 w-16 rounded-full bg-muted animate-pulse shrink-0" />
+            <div className="space-y-2 min-w-0 flex-1">
+              <div className="h-8 w-48 bg-muted animate-pulse rounded" />
+              <div className="h-4 w-full max-w-md bg-muted animate-pulse rounded" />
+            </div>
+          </div>
+          <ScoreSkeleton />
+        </div>
+      </Container>
+
+      {/* Recent activity skeleton */}
+      <Container>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="space-y-2">
+              <div className="h-3 w-20 bg-muted animate-pulse rounded" />
+              <div className="h-5 w-32 bg-muted animate-pulse rounded" />
+            </div>
+          ))}
+        </div>
+      </Container>
+
+      {/* Activity chart skeleton */}
+      <Container>
+        <section className="space-y-4">
+          <div className="h-4 w-20 bg-muted animate-pulse rounded" />
+          <CommitChartSkeleton />
+        </section>
+      </Container>
+
+      {/* Maintenance health skeleton */}
+      <Container>
+        <section className="space-y-4">
+          <div className="h-4 w-32 bg-muted animate-pulse rounded" />
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {[1, 2, 3, 4].map((i) => (
+              <Card key={i}>
+                <CardContent className="space-y-2">
+                  <div className="h-4 w-24 bg-muted animate-pulse rounded" />
+                  <div className="h-6 w-16 bg-muted animate-pulse rounded" />
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </section>
+      </Container>
+    </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import { Hero } from "@/app/_components/hero";
 import { HowItWorks } from "@/app/_components/how-it-works";
 import { RecentAnalyses } from "@/app/_components/recent-analyses";
@@ -12,12 +13,29 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function Home() {
+export default function Home() {
   return (
     <main className="space-y-8 py-6">
       <Hero />
-      <RecentAnalyses />
+      <Suspense fallback={<RecentAnalysesSkeleton />}>
+        <RecentAnalyses />
+      </Suspense>
       <HowItWorks />
     </main>
+  );
+}
+
+function RecentAnalysesSkeleton() {
+  return (
+    <section className="bg-surface-2 animate-pulse">
+      <div className="container mx-auto px-4 py-8 space-y-4">
+        <div className="h-7 w-40 bg-muted rounded" />
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <div key={i} className="h-24 bg-muted rounded-lg" />
+          ))}
+        </div>
+      </div>
+    </section>
   );
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "bunVersion": "1.x",
   "buildCommand": "bun run db:migrate && bun run build"
 }


### PR DESCRIPTION
- Replace unstable_cache with "use cache" directive (Next.js 16+)
- Increase project cache TTL from 24h to 7 days
- Add 5-minute cache for recent assessments with tag invalidation
- Enable cacheComponents in next.config.ts
- Wrap pages in Suspense for cacheComponents compatibility
- Add skeleton components for loading states
- Remove Bun runtime, use Node.js for Cache Components support
- Update vercel.json to remove bunVersion for proper runtime

Closes #16
Closes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced animated placeholder screens that display while pages load, providing visual feedback and a smoother user experience during data fetching.

* **Performance**
  * Extended data cache retention to 7 days, reducing load times on repeat visits to frequently accessed pages.
  * Enhanced page rendering through optimized lazy loading of content sections and improved caching.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->