### PR TITLE
fix(ui): eliminate skeleton flash for cached projects

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,14 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "includes": ["**", "!node_modules", "!.next", "!dist", "!build", "!migrations"]
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build",
+      "!migrations"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/src/app/p/[owner]/[project]/_components/chart-skeletons.tsx
+++ b/src/app/p/[owner]/[project]/_components/chart-skeletons.tsx
@@ -1,4 +1,3 @@
-import { Container } from "@/components/container";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 
 export function CommitChartSkeleton() {
@@ -32,62 +31,5 @@ export function ScoreSkeleton() {
         <div className="h-3 w-32 bg-muted animate-pulse rounded" />
       </CardContent>
     </Card>
-  );
-}
-
-export function ProjectPageSkeleton() {
-  return (
-    <>
-      {/* Header skeleton */}
-      <Container>
-        <div className="flex flex-col sm:flex-row sm:items-start gap-6">
-          <div className="flex items-start gap-4 flex-1 min-w-0">
-            <div className="h-16 w-16 rounded-full bg-muted animate-pulse shrink-0" />
-            <div className="space-y-2 min-w-0 flex-1">
-              <div className="h-8 w-48 bg-muted animate-pulse rounded" />
-              <div className="h-4 w-full max-w-md bg-muted animate-pulse rounded" />
-            </div>
-          </div>
-          <ScoreSkeleton />
-        </div>
-      </Container>
-
-      {/* Recent activity skeleton */}
-      <Container>
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-          {[1, 2, 3].map((i) => (
-            <div key={i} className="space-y-2">
-              <div className="h-3 w-20 bg-muted animate-pulse rounded" />
-              <div className="h-5 w-32 bg-muted animate-pulse rounded" />
-            </div>
-          ))}
-        </div>
-      </Container>
-
-      {/* Activity chart skeleton */}
-      <Container>
-        <section className="space-y-4">
-          <div className="h-4 w-20 bg-muted animate-pulse rounded" />
-          <CommitChartSkeleton />
-        </section>
-      </Container>
-
-      {/* Maintenance health skeleton */}
-      <Container>
-        <section className="space-y-4">
-          <div className="h-4 w-32 bg-muted animate-pulse rounded" />
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {[1, 2, 3, 4].map((i) => (
-              <Card key={i}>
-                <CardContent className="space-y-2">
-                  <div className="h-4 w-24 bg-muted animate-pulse rounded" />
-                  <div className="h-6 w-16 bg-muted animate-pulse rounded" />
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </section>
-      </Container>
-    </>
   );
 }

--- a/src/app/p/[owner]/[project]/_components/score-display.tsx
+++ b/src/app/p/[owner]/[project]/_components/score-display.tsx
@@ -8,7 +8,7 @@ import { getCategoryFromScore } from "@/lib/maintenance";
 
 interface ScoreDisplayProps {
   score: number;
-  analyzedAt: Date;
+  analyzedAt: Date | string;
 }
 
 export function ScoreDisplay({ score, analyzedAt }: ScoreDisplayProps) {


### PR DESCRIPTION
Remove the top-level Suspense boundary from the project page so React's transition mechanism keeps the previous page visible during navigation. Render score and chart directly when the assessment is complete, only deferring to Suspense for incomplete assessments still awaiting commit activity data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined page layout and component structure for improved load time handling based on data availability.

* **Chores**
  * Updated configuration formatting for better readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->