### PR TITLE
Add helper to link env files in worktrees

### DIFF
--- a/scripts/link-env.sh
+++ b/scripts/link-env.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run this inside a worktree.
+main_root="$(cd "$(git rev-parse --git-common-dir)"/.. && pwd)"
+target_root="$(git rev-parse --show-toplevel)"
+
+if [[ "$target_root" == "$main_root" ]]; then
+  echo "Already in main worktree; nothing to link."
+  exit 0
+fi
+
+link_file() {
+  local name="$1"
+  local src="$main_root/$name"
+  local dest="$target_root/$name"
+
+  [[ -f "$src" ]] || return 0
+  if [[ -e "$dest" ]]; then
+    echo "Skip $name: already exists at $dest"
+    return 0
+  fi
+
+  ln -s "$src" "$dest"
+  echo "Linked $name -> $src"
+}
+
+link_file ".env.local"
+link_file ".env"


### PR DESCRIPTION
## Summary
- add a dedicated script that links `.env.local` and `.env` from the main worktree into a new worktree so the variables stay in sync
- skip linking when files already exist or when run inside the main worktree for safety

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a utility script to streamline environment file management across Git worktrees, automatically linking configuration files while safely handling existing destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->