### PR TITLE
Align analysis cache life with freshness window

### DIFF
--- a/src/app/p/[owner]/[project]/_components/commit-chart-content.tsx
+++ b/src/app/p/[owner]/[project]/_components/commit-chart-content.tsx
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { cacheLife, cacheTag } from "next/cache";
+import { ANALYSIS_CACHE_LIFE } from "@/lib/cache/analysis-cache";
 import { getProjectTag } from "@/lib/cache/tags";
 import { ensureScoreCompletion } from "@/lib/services/assessment-service";
 import { CommitActivityChart } from "./commit-activity-chart";
@@ -17,7 +18,7 @@ export async function CommitChartContent({
   project,
 }: CommitChartContentProps) {
   "use cache";
-  cacheLife("weeks");
+  cacheLife(ANALYSIS_CACHE_LIFE);
   cacheTag(getProjectTag(owner, project));
 
   const run = await ensureScoreCompletion(owner, project, runId);

--- a/src/app/p/[owner]/[project]/_components/score.tsx
+++ b/src/app/p/[owner]/[project]/_components/score.tsx
@@ -6,6 +6,7 @@ import { LocalDate } from "@/components/local-date";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
+import { ANALYSIS_CACHE_LIFE } from "@/lib/cache/analysis-cache";
 import { getProjectTag } from "@/lib/cache/tags";
 import { categoryColors } from "@/lib/category-styles";
 import { getCategoryFromScore } from "@/lib/maintenance";
@@ -19,7 +20,7 @@ interface ScoreProps {
 
 export async function Score({ runId, owner, project }: ScoreProps) {
   "use cache";
-  cacheLife("weeks");
+  cacheLife(ANALYSIS_CACHE_LIFE);
   cacheTag(getProjectTag(owner, project));
 
   const run = await ensureScoreCompletion(owner, project, runId);

--- a/src/app/p/[owner]/[project]/layout.tsx
+++ b/src/app/p/[owner]/[project]/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, ResolvingMetadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
+import { ANALYSIS_CACHE_LIFE } from "@/lib/cache/analysis-cache";
 import { getProjectTag } from "@/lib/cache/tags";
 import { getCategoryFromScore } from "@/lib/maintenance";
 import { getLatestRun } from "@/lib/services/assessment-service";
@@ -11,7 +12,7 @@ type Props = {
 
 async function getCachedRunForMetadata(owner: string, project: string) {
   "use cache";
-  cacheLife("weeks");
+  cacheLife(ANALYSIS_CACHE_LIFE);
   cacheTag(getProjectTag(owner, project));
 
   return getLatestRun(owner, project);

--- a/src/app/p/[owner]/[project]/page.tsx
+++ b/src/app/p/[owner]/[project]/page.tsx
@@ -1,5 +1,6 @@
 import { cacheLife, cacheTag } from "next/cache";
 import { getProjectTag } from "@/lib/cache/tags";
+import { ANALYSIS_CACHE_LIFE } from "@/lib/cache/analysis-cache";
 import { startAnalysis } from "@/lib/services/assessment-service";
 import { CommitChart } from "./_components/commit-chart";
 import { MaintenanceHealth } from "./_components/maintenance-health";
@@ -19,7 +20,7 @@ export default async function ProjectPage({
 }: PageProps<"/p/[owner]/[project]">) {
   "use cache";
   const { owner, project } = await params;
-  cacheLife("weeks");
+  cacheLife(ANALYSIS_CACHE_LIFE);
   cacheTag(getProjectTag(owner, project));
 
   const run = await startAnalysis(owner, project);

--- a/src/lib/cache/analysis-cache.ts
+++ b/src/lib/cache/analysis-cache.ts
@@ -1,0 +1,17 @@
+import type { AnalysisRun } from "@/lib/domain/assessment";
+
+export const ANALYSIS_FRESHNESS_SECONDS = 60 * 60 * 24 * 7;
+export const ANALYSIS_CACHE_LIFE = {
+  stale: 300,
+  revalidate: ANALYSIS_FRESHNESS_SECONDS,
+  expire: ANALYSIS_FRESHNESS_SECONDS + 3600,
+} as const;
+
+export function isAnalysisFresh(
+  run: Pick<AnalysisRun, "startedAt" | "completedAt">,
+  now: Date = new Date(),
+): boolean {
+  const timestamp = run.completedAt ?? run.startedAt;
+  const ageSeconds = (now.getTime() - timestamp.getTime()) / 1000;
+  return ageSeconds < ANALYSIS_FRESHNESS_SECONDS;
+}

--- a/src/lib/services/assessment-service.ts
+++ b/src/lib/services/assessment-service.ts
@@ -15,14 +15,7 @@ import {
   getRepositoryByFullName,
   upsertRepository,
 } from "@/lib/persistence/repository-repo";
-
-const CACHE_REVALIDATE_SECONDS = 60 * 60 * 24 * 7;
-
-function isRunFresh(run: AnalysisRun): boolean {
-  const timestamp = run.completedAt ?? run.startedAt;
-  const ageSeconds = (Date.now() - timestamp.getTime()) / 1000;
-  return ageSeconds < CACHE_REVALIDATE_SECONDS;
-}
+import { isAnalysisFresh } from "@/lib/cache/analysis-cache";
 
 function toMetricsSnapshot(metrics: {
   description: MetricsSnapshot["description"];
@@ -111,7 +104,7 @@ export async function startAnalysis(
   project: string,
 ): Promise<AnalysisRun> {
   const latest = await getLatestRun(owner, project);
-  if (latest && isRunFresh(latest)) {
+  if (latest && isAnalysisFresh(latest)) {
     return latest;
   }
 


### PR DESCRIPTION
## Summary
- add shared cache config for analysis freshness and reuse it across services and cached components
- swap all cached renderers to the single `ANALYSIS_CACHE_LIFE` profile so TTLs stay consistent
- use the shared `isAnalysisFresh` helper in the assessment service

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized cache duration configuration across analysis data retrieval by centralizing cache lifecycle policies into a reusable utility module.
  * Consolidated cache freshness verification logic from multiple services into a single shared utility function for consistent analysis data freshness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->