### PR TITLE
fix(analysis): retrigger commit activity fetch on incomplete data

### DIFF
--- a/src/lib/services/assessment-service.ts
+++ b/src/lib/services/assessment-service.ts
@@ -143,7 +143,11 @@ export async function ensureScoreCompletion(
     throw new Error("Analysis run not found");
   }
 
-  if (run.status === "complete" && run.score !== null) {
+  if (
+    run.status === "complete" &&
+    run.score !== null &&
+    run.commitActivity.length > 0
+  ) {
     return run;
   }
 


### PR DESCRIPTION
## Summary

- When GitHub's commit activity API returns 202 (stats computing) and all retries are exhausted, `fetchCommitActivity()` stores an empty array `[]`. Previously, once a run was marked "complete" with a score, this empty data was never re-fetched — the early-return guard in `ensureScoreCompletion()` skipped re-evaluation.
- Now, completed runs with empty commit activity are detected as incomplete and fall through to the existing re-fetch logic. If GitHub returns data on retry, the score is recalculated and the page cache is invalidated.

## How it works

GitHub always returns 52 weekly entries even for repos with zero commits, so `commitActivity.length === 0` reliably signals a failed fetch — not a legitimately inactive repo.

The fix adds one condition to the early-return guard and schedules cache invalidation via `after()` when commit activity is successfully recovered for a previously-complete run.

## Test plan

- [x] `bun run check-types` — no new type errors
- [x] `bun run lint` — passes
- [x] `bun run test` — all 45 tests pass

Closes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Require at least one commit activity entry before marking an assessment run as complete, preventing premature completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->