### PR TITLE
chore(db): drop unused legacy assessments table

### DIFF
--- a/migrations/0005_glossy_sage.sql
+++ b/migrations/0005_glossy_sage.sql
@@ -1,0 +1,1 @@
+DROP TABLE "assessments" CASCADE;

--- a/migrations/meta/0005_snapshot.json
+++ b/migrations/meta/0005_snapshot.json
@@ -1,0 +1,206 @@
+{
+  "id": "37f32b22-9b64-4500-b7fd-a2f23917a18a",
+  "prevId": "1339c511-a40c-4cd6-94ef-e3cc306a2a37",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analysis_runs": {
+      "name": "analysis_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'complete'"
+        },
+        "metrics_json": {
+          "name": "metrics_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "analysis_runs_repository_id_idx": {
+          "name": "analysis_runs_repository_id_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analysis_runs_repository_completed_idx": {
+          "name": "analysis_runs_repository_completed_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analysis_runs_repository_id_repositories_id_fk": {
+          "name": "analysis_runs_repository_id_repositories_id_fk",
+          "tableFrom": "analysis_runs",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repositories": {
+      "name": "repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repositories_full_name_idx": {
+          "name": "repositories_full_name_idx",
+          "columns": [
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1770868471175,
       "tag": "0004_smooth_namor",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1770872904865,
+      "tag": "0005_glossy_sage",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,11 +1,9 @@
 import { relations } from "drizzle-orm";
 import {
-  boolean,
   index,
   integer,
   jsonb,
   pgTable,
-  real,
   serial,
   text,
   timestamp,
@@ -13,54 +11,6 @@ import {
 } from "drizzle-orm/pg-core";
 import type { MetricsSnapshot } from "@/lib/domain/assessment";
 import type { AnalysisStatus } from "@/lib/domain/score";
-
-export const legacyAssessments = pgTable(
-  "assessments",
-  {
-    id: serial("id").primaryKey(),
-    owner: text("owner").notNull(),
-    repo: text("repo").notNull(),
-    fullName: text("full_name").notNull(),
-    description: text("description"),
-    stars: integer("stars").default(0),
-    forks: integer("forks").default(0),
-    avatarUrl: text("avatar_url"),
-    htmlUrl: text("html_url"),
-    license: text("license"),
-    language: text("language"),
-    repositoryCreatedAt: timestamp("repository_created_at"),
-    lastCommitAt: timestamp("last_commit_at"),
-    lastReleaseAt: timestamp("last_release_at"),
-    lastClosedIssueAt: timestamp("last_closed_issue_at"),
-    commitsLastYear: integer("commits_last_year"),
-    openIssuesPercent: real("open_issues_percent"),
-    openIssuesCount: integer("open_issues_count"),
-    closedIssuesCount: integer("closed_issues_count"),
-    medianIssueResolutionDays: real("median_issue_resolution_days"),
-    openPrsCount: integer("open_prs_count"),
-    issuesCreatedLastYear: integer("issues_created_last_year"),
-    isArchived: boolean("is_archived").default(false),
-    commitActivity:
-      jsonb("commit_activity").$type<
-        Array<{ week: string; commits: number }>
-      >(),
-    releases:
-      jsonb("releases").$type<
-        Array<{ tagName: string; name: string | null; publishedAt: string }>
-      >(),
-    maintenanceScore: integer("maintenance_score"),
-    status: text("status").notNull().default("scoring"),
-    analyzedAt: timestamp("analyzed_at").notNull().defaultNow(),
-    createdAt: timestamp("created_at").notNull().defaultNow(),
-  },
-  (table) => [
-    uniqueIndex("assessments_full_name_idx").on(table.fullName),
-    index("assessments_analyzed_at_idx").on(table.analyzedAt),
-  ],
-);
-
-export type LegacyAssessment = typeof legacyAssessments.$inferSelect;
-export type NewLegacyAssessment = typeof legacyAssessments.$inferInsert;
 
 export const repositories = pgTable(
   "repositories",


### PR DESCRIPTION
## Summary
- Remove the unused `legacyAssessments` table definition and its types (`LegacyAssessment`, `NewLegacyAssessment`) from `src/db/schema.ts`
- Clean up unused drizzle-orm imports (`boolean`, `real`) that were only referenced by the legacy table
- Add migration `0005_glossy_sage.sql` to `DROP TABLE "assessments" CASCADE`

Closes #42

## Test plan
- [x] `bun run check-types` passes
- [x] `bun run test` passes (49 tests)
- [x] Generated migration contains `DROP TABLE "assessments" CASCADE`
- [ ] Verify preview deployment applies migration successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the legacy assessments table from the database schema and updated database migrations accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->