### PR TITLE
feat(activity): add timeline chart for recent activity

### DIFF
--- a/src/app/_components/how-it-works.tsx
+++ b/src/app/_components/how-it-works.tsx
@@ -6,9 +6,9 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { Badge } from "@/components/ui/badge";
-import { categoryColors } from "@/lib/category-styles";
 import { MAINTENANCE_CONFIG } from "@/core/maintenance";
 import type { FreshnessStep } from "@/core/scoring/types";
+import { categoryColors } from "@/lib/category-styles";
 
 const {
   categoryThresholds,

--- a/src/app/_components/recent-analyses.tsx
+++ b/src/app/_components/recent-analyses.tsx
@@ -7,11 +7,11 @@ import Link from "next/link";
 import { Container } from "@/components/container";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
+import { listRecentCompletedAssessments } from "@/core/assessment";
+import { computeScoreFromMetrics } from "@/core/maintenance";
 import { HOMEPAGE_CACHE_LIFE } from "@/lib/cache/analysis-cache";
 import { getRecentAnalysesTag } from "@/lib/cache/tags";
 import { categoryColors } from "@/lib/category-styles";
-import { computeScoreFromMetrics } from "@/core/maintenance";
-import { listRecentCompletedAssessments } from "@/core/assessment";
 import { formatNumber } from "@/lib/utils";
 
 export async function RecentAnalyses() {

--- a/src/app/p/[owner]/[project]/_components/category-info-popover.tsx
+++ b/src/app/p/[owner]/[project]/_components/category-info-popover.tsx
@@ -7,11 +7,11 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { categoryColors } from "@/lib/category-styles";
 import {
   MAINTENANCE_CATEGORY_INFO,
   type MaintenanceCategory,
 } from "@/core/maintenance";
+import { categoryColors } from "@/lib/category-styles";
 import { cn } from "@/lib/utils";
 
 interface CategoryInfoPopoverProps {

--- a/src/app/p/[owner]/[project]/_components/recent-activity-content.tsx
+++ b/src/app/p/[owner]/[project]/_components/recent-activity-content.tsx
@@ -1,65 +1,240 @@
 "use client";
 
-import { format, formatDistanceToNow } from "date-fns";
-import { CheckCircle2, GitCommit, Tag } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { differenceInDays, format, formatDistanceToNow } from "date-fns";
+import type { LucideIcon } from "lucide-react";
+import { CheckCircle2, GitCommit, GitPullRequest, Tag } from "lucide-react";
+import {
+  CartesianGrid,
+  LabelList,
+  Scatter,
+  ScatterChart,
+  XAxis,
+  YAxis,
+} from "recharts";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+} from "@/components/ui/chart";
 import type { AnalysisRun } from "@/lib/domain/assessment";
+
+type Recency = "recent" | "moderate" | "aging" | "stale";
+
+interface TimelinePoint {
+  timestamp: number;
+  y: number;
+  label: string;
+  recency: Recency;
+  icon: LucideIcon;
+  date: Date;
+}
+
+const recencyColor: Record<Recency, string> = {
+  recent: "var(--status-healthy)",
+  moderate: "var(--status-moderate)",
+  aging: "var(--status-declining)",
+  stale: "var(--status-inactive)",
+};
+
+function getRecency(date: Date): Recency {
+  const days = differenceInDays(new Date(), date);
+  if (days <= 30) return "recent";
+  if (days <= 90) return "moderate";
+  if (days <= 180) return "aging";
+  return "stale";
+}
+
+const chartConfig: ChartConfig = {
+  recent: { label: "Recent", color: "var(--status-healthy)" },
+  moderate: { label: "Moderate", color: "var(--status-moderate)" },
+  aging: { label: "Aging", color: "var(--status-declining)" },
+  stale: { label: "Inactive", color: "var(--status-inactive)" },
+};
 
 interface RecentActivityContentProps {
   run: AnalysisRun;
 }
 
-const iconClass = "w-4 h-4 text-muted-foreground";
+function TimelineMarker({
+  cx,
+  cy,
+  payload,
+}: {
+  cx?: number;
+  cy?: number;
+  payload?: TimelinePoint;
+}) {
+  if (cx == null || cy == null || !payload) return null;
+  const Icon = payload.icon;
+  const color = recencyColor[payload.recency];
+  return (
+    <foreignObject x={cx - 12} y={cy - 12} width={24} height={24}>
+      <div
+        className="flex items-center justify-center size-full rounded-full shadow-sm"
+        style={{ backgroundColor: color }}
+      >
+        <Icon className="size-3 text-white" />
+      </div>
+    </foreignObject>
+  );
+}
 
-function formatActivityDate(date: Date | string | null): {
-  display: string;
-  relative: string;
-} {
-  if (!date) return { display: "N/A", relative: "No activity recorded" };
-  const d = new Date(date);
-  return {
-    display: format(d, "MMM d, yyyy"),
-    relative: formatDistanceToNow(d, { addSuffix: true }),
-  };
+function TimelineLabel({
+  x,
+  y,
+  value,
+}: {
+  x?: number;
+  y?: number;
+  value?: string;
+}) {
+  if (x == null || y == null || !value) return null;
+  return (
+    <foreignObject x={x - 55} y={y - 26} width={110} height={20}>
+      <div className="hidden sm:flex items-center justify-center">
+        <span className="text-xs font-medium text-foreground truncate">
+          {value}
+        </span>
+      </div>
+    </foreignObject>
+  );
+}
+
+function CustomTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: Array<{ payload: TimelinePoint }>;
+}) {
+  if (!active || !payload?.length) return null;
+  const point = payload[0].payload;
+  const Icon = point.icon;
+  const color = recencyColor[point.recency];
+  return (
+    <div className="bg-surface-3 border border-border rounded-lg px-3 py-2 shadow-xl text-xs">
+      <div className="flex items-center gap-1.5 font-medium text-foreground">
+        <Icon className="size-3.5" style={{ color }} />
+        {point.label}
+      </div>
+      <div className="text-muted-foreground mt-1">
+        {format(point.date, "MMM d, yyyy")}
+      </div>
+      <div className="text-muted-foreground">
+        {formatDistanceToNow(point.date, { addSuffix: true })}
+      </div>
+    </div>
+  );
 }
 
 export function RecentActivityContent({ run }: RecentActivityContentProps) {
   const metrics = run.metrics;
 
-  const activityMetrics = [
+  const rawMetrics: Array<{
+    date: string | null;
+    label: string;
+    icon: LucideIcon;
+  }> = [
     {
-      title: "Last Commit",
-      ...formatActivityDate(metrics?.lastCommitAt ?? null),
-      icon: <GitCommit className={iconClass} />,
+      date: metrics?.lastCommitAt ?? null,
+      label: "Last Commit",
+      icon: GitCommit,
+    },
+    { date: metrics?.lastReleaseAt ?? null, label: "Last Release", icon: Tag },
+    {
+      date: metrics?.lastClosedIssueAt ?? null,
+      label: "Last Issue Closed",
+      icon: CheckCircle2,
     },
     {
-      title: "Last Release",
-      ...formatActivityDate(metrics?.lastReleaseAt ?? null),
-      icon: <Tag className={iconClass} />,
-    },
-    {
-      title: "Last Issue Closed",
-      ...formatActivityDate(metrics?.lastClosedIssueAt ?? null),
-      icon: <CheckCircle2 className={iconClass} />,
+      date: metrics?.lastMergedPrAt ?? null,
+      label: "Last PR Merged",
+      icon: GitPullRequest,
     },
   ];
 
+  const filtered = rawMetrics
+    .filter((m): m is typeof m & { date: string } => m.date !== null)
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  const yStep = filtered.length > 1 ? 5 / (filtered.length - 1) : 0;
+  const points: TimelinePoint[] = filtered.map((m, i) => {
+    const d = new Date(m.date);
+    return {
+      timestamp: d.getTime(),
+      y: 1 + i * yStep,
+      label: m.label,
+      recency: getRecency(d),
+      icon: m.icon,
+      date: d,
+    };
+  });
+
+  const missingLabels = rawMetrics
+    .filter((m) => m.date === null)
+    .map((m) => m.label);
+
+  if (points.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">No activity recorded.</p>
+    );
+  }
+
+  const earliest = points[0].date;
+  const rangeEnd = Date.now();
+  const span = rangeEnd - earliest.getTime();
+  const padding = Math.max(
+    14 * 86_400_000,
+    Math.min(span * 0.1, 90 * 86_400_000),
+  );
+  const rangeStart = earliest.getTime() - padding;
+  const rangeDays = (rangeEnd - rangeStart) / 86_400_000;
+
+  const TICK_COUNT = 5;
+  const step = (rangeEnd - rangeStart) / (TICK_COUNT + 1);
+  const ticks = Array.from(
+    { length: TICK_COUNT },
+    (_, i) => rangeStart + step * (i + 1),
+  );
+  const formatTick = (ts: number) =>
+    rangeDays <= 180
+      ? format(new Date(ts), "MMM d")
+      : format(new Date(ts), "MMM ''yy");
+
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-      {activityMetrics.map((metric) => (
-        <Card key={metric.title}>
-          <CardHeader className="flex flex-row items-center justify-between">
-            <CardTitle className="text-sm font-medium">
-              {metric.title}
-            </CardTitle>
-            {metric.icon}
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{metric.display}</div>
-            <p className="text-xs text-muted-foreground">{metric.relative}</p>
-          </CardContent>
-        </Card>
-      ))}
+    <div className="space-y-2">
+      <ChartContainer
+        config={chartConfig}
+        className="aspect-auto h-[200px] w-full"
+      >
+        <ScatterChart margin={{ top: 40, right: 20, bottom: 0, left: 20 }}>
+          <CartesianGrid
+            vertical
+            horizontal={false}
+            strokeDasharray="3 3"
+            stroke="var(--border)"
+          />
+          <XAxis
+            type="number"
+            dataKey="timestamp"
+            domain={[rangeStart, rangeEnd]}
+            ticks={ticks}
+            tickFormatter={formatTick}
+            axisLine={{ stroke: "var(--border)" }}
+            tickLine={{ stroke: "var(--border)" }}
+            tick={{ fontSize: 12, fill: "var(--foreground)" }}
+          />
+          <YAxis type="number" dataKey="y" domain={[0, 6]} hide />
+          <ChartTooltip cursor={false} content={<CustomTooltip />} />
+          <Scatter data={points} shape={<TimelineMarker />}>
+            <LabelList dataKey="label" content={<TimelineLabel />} />
+          </Scatter>
+        </ScatterChart>
+      </ChartContainer>
+      {missingLabels.length > 0 && (
+        <p className="text-xs text-muted-foreground">
+          No data: {missingLabels.join(", ")}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/app/p/[owner]/[project]/_components/recent-activity-skeleton.tsx
+++ b/src/app/p/[owner]/[project]/_components/recent-activity-skeleton.tsx
@@ -1,20 +1,10 @@
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
-
 export function RecentActivitySkeleton() {
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-      {[1, 2, 3].map((i) => (
-        <Card key={i}>
-          <CardHeader className="flex flex-row items-center justify-between">
-            <div className="h-4 w-20 bg-muted animate-pulse rounded" />
-            <div className="h-4 w-4 bg-muted animate-pulse rounded" />
-          </CardHeader>
-          <CardContent>
-            <div className="h-7 w-28 bg-muted animate-pulse rounded mb-1" />
-            <div className="h-3 w-20 bg-muted animate-pulse rounded" />
-          </CardContent>
-        </Card>
-      ))}
+    <div className="h-[200px] w-full rounded-lg border border-border bg-surface-2/50 relative overflow-hidden">
+      <div className="absolute inset-x-8 bottom-6 h-px bg-muted animate-pulse" />
+      <div className="absolute left-[20%] top-[25%] size-7 rounded-full bg-muted animate-pulse" />
+      <div className="absolute left-[50%] top-[45%] size-7 rounded-full bg-muted animate-pulse" />
+      <div className="absolute left-[75%] top-[65%] size-7 rounded-full bg-muted animate-pulse" />
     </div>
   );
 }

--- a/src/app/p/[owner]/[project]/_components/score.tsx
+++ b/src/app/p/[owner]/[project]/_components/score.tsx
@@ -5,8 +5,8 @@ import { LocalDate } from "@/components/local-date";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
-import type { AnalysisRun } from "@/lib/domain/assessment";
 import { computeScoreFromMetrics } from "@/core/maintenance";
+import type { AnalysisRun } from "@/lib/domain/assessment";
 import { CategoryInfoPopover } from "./category-info-popover";
 
 interface ScoreProps {

--- a/src/app/p/[owner]/[project]/layout.tsx
+++ b/src/app/p/[owner]/[project]/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata, ResolvingMetadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
+import { findLatestAssessmentRunBySlug } from "@/core/assessment";
+import { computeScoreFromMetrics } from "@/core/maintenance";
 import { ANALYSIS_CACHE_LIFE } from "@/lib/cache/analysis-cache";
 import { getProjectTag } from "@/lib/cache/tags";
-import { computeScoreFromMetrics } from "@/core/maintenance";
-import { findLatestAssessmentRunBySlug } from "@/core/assessment";
 
 type Props = {
   params: Promise<{ owner: string; project: string }>;

--- a/src/app/p/[owner]/[project]/page.tsx
+++ b/src/app/p/[owner]/[project]/page.tsx
@@ -1,7 +1,7 @@
 import { cacheLife, cacheTag } from "next/cache";
+import { ensureAssessmentRunStarted } from "@/core/assessment";
 import { ANALYSIS_CACHE_LIFE } from "@/lib/cache/analysis-cache";
 import { getProjectTag } from "@/lib/cache/tags";
-import { ensureAssessmentRunStarted } from "@/core/assessment";
 import { MaintenanceHealth } from "./_components/maintenance-health";
 import { ProjectHeader } from "./_components/project-header";
 import { ReadmeSection } from "./_components/readme-section";

--- a/src/core/assessment/mutations.test.ts
+++ b/src/core/assessment/mutations.test.ts
@@ -22,10 +22,10 @@ vi.mock("./queries", () => ({
   findLatestAssessmentRunBySlug: vi.fn(),
 }));
 
-import { isAnalysisFresh } from "@/lib/cache/analysis-cache";
 import { fetchRepoMetrics } from "@/adapters/github";
 import { createAssessmentRun } from "@/adapters/persistence/analysis-run";
 import { upsertRepository } from "@/adapters/persistence/repository";
+import { isAnalysisFresh } from "@/lib/cache/analysis-cache";
 import { findLatestAssessmentRunBySlug } from "./queries";
 
 function makeRun(overrides: Partial<AnalysisRun> = {}): AnalysisRun {

--- a/src/core/assessment/mutations.ts
+++ b/src/core/assessment/mutations.ts
@@ -1,10 +1,10 @@
 import "server-only";
 
-import { isAnalysisFresh } from "@/lib/cache/analysis-cache";
-import type { AnalysisRun } from "@/lib/domain/assessment";
 import { fetchRepoMetrics } from "@/adapters/github";
 import { createAssessmentRun } from "@/adapters/persistence/analysis-run";
 import { upsertRepository } from "@/adapters/persistence/repository";
+import { isAnalysisFresh } from "@/lib/cache/analysis-cache";
+import type { AnalysisRun } from "@/lib/domain/assessment";
 import { findLatestAssessmentRunBySlug } from "./queries";
 import { toMetricsSnapshot } from "./snapshot-mapper";
 

--- a/src/core/assessment/queries.ts
+++ b/src/core/assessment/queries.ts
@@ -1,12 +1,12 @@
 import "server-only";
 
-import type { AnalysisRun } from "@/lib/domain/assessment";
 import {
   findLatestAssessmentRunByRepositoryId,
   listAssessmentRunsByRepositoryId,
   listRecentCompletedAssessmentRuns,
 } from "@/adapters/persistence/analysis-run";
 import { findRepositoryByFullName } from "@/adapters/persistence/repository";
+import type { AnalysisRun } from "@/lib/domain/assessment";
 
 export async function findLatestAssessmentRunBySlug(
   owner: string,

--- a/src/core/maintenance/maintenance.ts
+++ b/src/core/maintenance/maintenance.ts
@@ -1,8 +1,4 @@
 import type { MetricsSnapshot } from "@/lib/domain/assessment";
-import {
-  MAINTENANCE_CATEGORY_INFO,
-  type MaintenanceCategory,
-} from "./maintenance-config";
 import { calculateScore } from "../scoring";
 import type {
   ScoreBreakdown,
@@ -10,6 +6,10 @@ import type {
   ScoringInput,
   ScoringProfileId,
 } from "../scoring/types";
+import {
+  MAINTENANCE_CATEGORY_INFO,
+  type MaintenanceCategory,
+} from "./maintenance-config";
 
 export type { MaintenanceCategory };
 export type { ScoreOptions, ScoringProfileId };


### PR DESCRIPTION
## Summary
- Replace the 3-card activity grid with a Recharts ScatterChart timeline showing last commit, release, issue closed, and PR merged as positioned markers
- Color-code markers by recency: green (≤30d), blue (≤90d), yellow (≤180d), gray (stale)
- Adaptive tick formatting: day-level labels for short ranges, month-level for longer ranges
- Add vertical dashed grid lines, hover tooltips with exact + relative dates, and "No data" indicator for missing metrics
- Update skeleton to match new chart dimensions

## Test plan
- [x] `bun run check-types` passes
- [x] `bun run lint` passes
- [ ] Active project (e.g. next.js): all 4 markers visible with recent (green) coloring
- [ ] Stale project (e.g. clsx): markers spread across timeline with mixed colors, missing data note shown
- [ ] Short range (<6mo): tick labels show day-level format (e.g. "Jan 15")
- [ ] Long range (>1yr): tick labels show month format (e.g. "Jun '24")
- [ ] Responsive: labels hide on narrow viewport, markers remain visible and tappable