### PR TITLE
feat(activity): add metric cards and today reference line

### DIFF
--- a/src/app/p/[owner]/[project]/_components/recent-activity-skeleton.tsx
+++ b/src/app/p/[owner]/[project]/_components/recent-activity-skeleton.tsx
@@ -1,10 +1,27 @@
 export function RecentActivitySkeleton() {
   return (
-    <div className="h-[200px] w-full rounded-lg border border-border bg-surface-2/50 relative overflow-hidden">
-      <div className="absolute inset-x-8 bottom-6 h-px bg-muted animate-pulse" />
-      <div className="absolute left-[20%] top-[25%] size-7 rounded-full bg-muted animate-pulse" />
-      <div className="absolute left-[50%] top-[45%] size-7 rounded-full bg-muted animate-pulse" />
-      <div className="absolute left-[75%] top-[65%] size-7 rounded-full bg-muted animate-pulse" />
+    <div className="space-y-3">
+      <div className="h-[200px] w-full rounded-lg border border-border bg-surface-2/50 relative overflow-hidden">
+        <div className="absolute inset-x-8 bottom-6 h-px bg-muted animate-pulse" />
+        <div className="absolute left-[20%] top-[25%] size-7 rounded-full bg-muted animate-pulse" />
+        <div className="absolute left-[50%] top-[45%] size-7 rounded-full bg-muted animate-pulse" />
+        <div className="absolute left-[75%] top-[65%] size-7 rounded-full bg-muted animate-pulse" />
+      </div>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {["commit", "release", "issue", "pr"].map((slot) => (
+          <div
+            key={slot}
+            className="rounded-lg border border-border bg-surface-2/50 py-2.5 px-3 space-y-1.5 animate-pulse"
+          >
+            <div className="flex items-center gap-1.5">
+              <div className="size-3.5 rounded-full bg-muted" />
+              <div className="h-3 w-16 rounded bg-muted" />
+            </div>
+            <div className="h-4 w-20 rounded bg-muted" />
+            <div className="h-3 w-14 rounded bg-muted" />
+          </div>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add a grid of metric cards below the timeline chart showing each activity's date and relative time (replaces plain "No data" text)
- Add a dashed "Today" reference line on the scatter chart for temporal context
- Update skeleton to match the new card-based layout
- Extract inline type to a named `MetricDef` interface

## Test plan
- [ ] Verify metric cards render correctly with all four activity types
- [ ] Verify cards show "N/A" gracefully when a metric date is missing
- [ ] Verify the "Today" reference line appears on the chart
- [ ] Verify the skeleton matches the new layout structure
- [ ] Check responsive behavior on mobile (2-col) and desktop (4-col)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "today" marker to activity charts for temporal reference
  * Introduced metric cards displaying dates and time-ago formatting with color-coded recency indicators
  * Enhanced activity section with responsive card grid layout
  * Improved loading state UI to match updated layout structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->