### PR TITLE
perf: cache recent analyses on homepage

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -44,6 +44,7 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
+  cacheComponents: true,
   reactCompiler: true,
   images: {
     remotePatterns: [

--- a/src/app/_components/recent-analyses.tsx
+++ b/src/app/_components/recent-analyses.tsx
@@ -1,5 +1,6 @@
 import { fetchQuery } from "convex/nextjs";
 import { Code2, Star } from "lucide-react";
+import { cacheLife } from "next/cache";
 import Image from "next/image";
 import Link from "next/link";
 import { Container } from "@/components/container";
@@ -12,6 +13,9 @@ import { formatNumber } from "@/lib/utils";
 import { api } from "../../../convex/_generated/api";
 
 export async function RecentAnalyses() {
+  "use cache";
+  cacheLife("minutes");
+
   const recentRuns = (await fetchQuery(api.analysisRuns.listRecentCompleted, {
     limit: 12,
   })) as AnalysisRun[];


### PR DESCRIPTION
## Summary

- Add `"use cache"` with `cacheLife("minutes")` to the `RecentAnalyses` server component, serving cached renders on repeat homepage visits instead of hitting the Convex backend every page load
- Enable `cacheComponents` in Next.js config to unlock the `"use cache"` directive

## Test plan

- [ ] `bun run build` succeeds with `Cache Components` shown in banner
- [ ] Homepage `/` route shows `Revalidate 1m / Expire 1h` in build output
- [ ] Load homepage, reload — second load served from cache (faster response)

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled component and data caching mechanisms to improve app performance by reducing data fetch operations and load times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->