### PR TITLE
perf: cache static sections on project page

### DIFF
--- a/src/app/p/[owner]/[project]/page.tsx
+++ b/src/app/p/[owner]/[project]/page.tsx
@@ -1,4 +1,5 @@
 import { fetchQuery } from "convex/nextjs";
+import { cacheLife } from "next/cache";
 import type { AnalysisRun } from "@/lib/domain/assessment";
 import { api } from "../../../../../convex/_generated/api";
 import { CommitActivityLive } from "./_components/commit-activity-live";
@@ -8,12 +9,15 @@ import { ProjectHeader } from "./_components/project-header";
 import { ReadmeSection } from "./_components/readme-section";
 import { RecentActivity } from "./_components/recent-activity";
 
-export default async function ProjectPage({
-  params,
+async function CachedProjectPage({
+  owner,
+  project,
 }: {
-  params: Promise<{ owner: string; project: string }>;
+  owner: string;
+  project: string;
 }) {
-  const { owner, project } = await params;
+  "use cache";
+  cacheLife("minutes");
 
   const run = await fetchQuery(api.analysisRuns.getByRepositorySlug, {
     owner,
@@ -39,4 +43,13 @@ export default async function ProjectPage({
       <ReadmeSection run={safeRun} />
     </>
   );
+}
+
+export default async function ProjectPage({
+  params,
+}: {
+  params: Promise<{ owner: string; project: string }>;
+}) {
+  const { owner, project } = await params;
+  return <CachedProjectPage owner={owner} project={project} />;
 }


### PR DESCRIPTION
## Summary
- Extract page body into `CachedProjectPage` with `"use cache"` + `cacheLife("minutes")` to cache rendered output and skip Convex fetch on repeat visits
- `CommitActivityLive` client component still hydrates with live data via `useQuery`
- Follows the same pattern already used in `recent-analyses.tsx` on the homepage

## Test plan
- [ ] `bun run check-types` passes
- [ ] `bun run lint` passes
- [ ] `bun run build` succeeds — project route shows as Partial Prerender (`◐`)
- [ ] Visit a project page, reload — second load should be faster (cached)
- [ ] Commit activity still updates in real-time via client subscription

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Improved project page load times through optimized caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->