### PR TITLE
fix(analysis): schedule delayed retry for commit activity

### DIFF
--- a/convex/_shared/constants.ts
+++ b/convex/_shared/constants.ts
@@ -9,6 +9,8 @@ export const COMMIT_ACTIVITY_MAX_ATTEMPTS =
 
 export const ANALYSIS_FRESHNESS_MS = 60 * 60 * 24 * 7 * 1000;
 
+export const COMMIT_ACTIVITY_DELAYED_RETRY_MS = 15 * 60 * 1000;
+
 export function isTerminalRunState(
   state: AnalysisRunState | undefined,
 ): boolean {

--- a/convex/analysisRuns.ts
+++ b/convex/analysisRuns.ts
@@ -260,6 +260,31 @@ export const updateRunState = internalMutation({
   },
 });
 
+export const upgradePartialRun = internalMutation({
+  args: {
+    runId: v.id("analysisRuns"),
+    metricsJson: v.any(),
+  },
+  handler: async (ctx, { runId, metricsJson }) => {
+    const run = await ctx.db.get(runId);
+    if (!run) return;
+
+    if (run.runState !== "partial") return;
+    if (run.errorCode !== "commit_activity_retry_limit") return;
+
+    const now = Date.now();
+    await ctx.db.patch(runId, {
+      status: "complete",
+      runState: "complete",
+      metricsJson,
+      errorCode: undefined,
+      errorMessage: undefined,
+      updatedAt: now,
+      completedAt: now,
+    });
+  },
+});
+
 export const finalizeRun = internalMutation({
   args: {
     runId: v.id("analysisRuns"),


### PR DESCRIPTION
## Summary
- When commit activity fast retries exhaust (GitHub returns 202 six times), schedule a single delayed retry 15 minutes later via `ctx.scheduler.runAfter`
- New `upgradePartialRun` mutation bypasses the terminal-state guard to upgrade a `partial` run to `complete` when the delayed retry succeeds
- 403/404 repos (permanently unavailable) are excluded from delayed retries

## Test plan
- [ ] `bun run check-types` passes
- [ ] `bun run lint` passes
- [ ] `bun run test` — all 46 tests pass
- [ ] Deploy to Convex and verify `delayedCommitActivityRetry` appears as a registered function in the dashboard
- [ ] Trigger analysis on a repo where GitHub stats are not cached — confirm delayed retry fires after 15 minutes and chart appears without page refresh

Closes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry handling for commit activity analysis: failures now trigger a delayed retry and better recovery, reducing incomplete results.
* **New Features**
  * Automatic completion of previously partial analyses when a delayed retry succeeds, restoring full metrics and clearing error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->