### PR TITLE
feat(ui): add animated CTA button and input size variants

### DIFF
--- a/src/app/_components/search-form.tsx
+++ b/src/app/_components/search-form.tsx
@@ -4,7 +4,7 @@ import { useAction } from "convex/react";
 import { Loader2, Search } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { Button } from "@/components/ui/button";
+import { CtaButton } from "@/components/ui/cta-button";
 import { Input } from "@/components/ui/input";
 import { parseProject } from "@/lib/parse-project";
 import { api } from "../../../convex/_generated/api";
@@ -64,11 +64,12 @@ export function SearchForm() {
           className="flex-1"
           autoComplete="off"
           disabled={isPending}
+          size="lg"
         />
-        <Button type="submit" disabled={isPending}>
+        <CtaButton type="submit" disabled={isPending}>
           {isPending ? <Loader2 className="animate-spin" /> : <Search />}
           {isPending ? "Analyzing..." : "Analyze"}
-        </Button>
+        </CtaButton>
       </form>
       {error && <p className="text-sm text-destructive font-medium">{error}</p>}
     </div>

--- a/src/app/compare/_components/compare-form.tsx
+++ b/src/app/compare/_components/compare-form.tsx
@@ -5,6 +5,7 @@ import { ArrowRightLeft, Loader2, Search } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { CtaButton } from "@/components/ui/cta-button";
 import { Input } from "@/components/ui/input";
 import { parseProject } from "@/lib/parse-project";
 import { api } from "../../../../convex/_generated/api";
@@ -103,6 +104,7 @@ export function CompareForm({ initialA, initialB }: CompareFormProps) {
             disabled={pending}
             value={valueA}
             onChange={(e) => setValueA(e.target.value)}
+            size="lg"
           />
           {errorA && (
             <p className="text-xs text-destructive font-medium">{errorA}</p>
@@ -136,20 +138,21 @@ export function CompareForm({ initialA, initialB }: CompareFormProps) {
             disabled={pending}
             value={valueB}
             onChange={(e) => setValueB(e.target.value)}
+            size="lg"
           />
           {errorB && (
             <p className="text-xs text-destructive font-medium">{errorB}</p>
           )}
         </div>
 
-        <Button type="submit" disabled={pending} className="shrink-0">
+        <CtaButton type="submit" disabled={pending} className="shrink-0">
           {pending ? (
             <Loader2 className="animate-spin" aria-hidden="true" />
           ) : (
             <Search aria-hidden="true" />
           )}
           {pending ? "Comparing…" : "Compare"}
-        </Button>
+        </CtaButton>
       </div>
     </form>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -95,6 +95,9 @@
   --shadow-lg: var(--shadow-lg);
   --shadow-xl: var(--shadow-xl);
   --shadow-2xl: var(--shadow-2xl);
+
+  --animate-gradient-shift: gradient-shift 3s ease infinite;
+  --animate-border-swipe: border-swipe 4s linear infinite;
 }
 
 @layer base {
@@ -106,5 +109,26 @@
   }
   body {
     @apply bg-surface-1 text-foreground relative min-h-screen overflow-x-hidden;
+  }
+}
+
+@keyframes border-swipe {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes gradient-shift {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
   }
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,7 +9,8 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "text-primary-foreground bg-linear-135 from-primary via-ring to-primary [background-size:300%_100%] hover:animate-gradient-shift",
         destructive:
           "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:

--- a/src/components/ui/cta-button.tsx
+++ b/src/components/ui/cta-button.tsx
@@ -1,0 +1,35 @@
+import type { VariantProps } from "class-variance-authority";
+import type * as React from "react";
+
+import { Button, type buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+function CtaButton({
+  className,
+  children,
+  size,
+  ...props
+}: React.ComponentProps<"button"> &
+  Pick<VariantProps<typeof buttonVariants>, "size">) {
+  return (
+    <span
+      data-slot="cta-button"
+      className={cn(
+        "relative inline-flex p-0.5 overflow-hidden bg-border",
+        props.disabled && "opacity-50 pointer-events-none",
+        className,
+      )}
+    >
+      <span className="absolute inset-0 animate-border-swipe bg-linear-to-r from-transparent via-foreground to-transparent" />
+      <Button
+        size={size}
+        className="relative bg-none bg-surface-2 text-primary-foreground hover:bg-surface-3 transition-colors duration-300"
+        {...props}
+      >
+        {children}
+      </Button>
+    </span>
+  );
+}
+
+export { CtaButton };

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,28 +1,38 @@
+import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-/**
- * Render an input element with a comprehensive set of UI utility classes, data-slot="input", and all other props forwarded.
- *
- * @param className - Optional additional CSS classes that are merged with the component's default classes
- * @param props - Remaining native input properties forwarded to the underlying element
- * @returns A JSX input element with default styling, merged `className`, `data-slot="input"`, and forwarded props
- */
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+const inputVariants = cva(
+  "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 w-full min-w-0 border border-input bg-transparent text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      size: {
+        default: "h-9 px-3 py-1",
+        lg: "h-10 px-4 py-2",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  },
+);
+
+function Input({
+  className,
+  type,
+  size = "default",
+  ...props
+}: Omit<React.ComponentProps<"input">, "size"> &
+  VariantProps<typeof inputVariants>) {
   return (
     <input
       type={type}
       data-slot="input"
-      className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-        className,
-      )}
+      className={cn(inputVariants({ size, className }))}
       {...props}
     />
   );
 }
 
-export { Input };
+export { Input, inputVariants };


### PR DESCRIPTION
## Summary
- Add `CtaButton` component with animated border swipe effect, composing the existing `Button`
- Add gradient-shift hover animation to the default button variant
- Add `lg` size variant to `Input` using CVA to match the large button height
- Use `CtaButton` for primary actions on homepage and compare page

## Test plan
- [ ] Hover the "Analyze" button on homepage — border swipe animation loops smoothly
- [ ] Hover the "Compare" button on compare page — same swipe animation
- [ ] Hover any default `Button` (e.g. error page) — gradient shifts on hover
- [ ] Verify `lg` inputs on homepage and compare page match button height
- [ ] Verify disabled state dims the CTA button and blocks interaction
- [ ] Verify no layout shift from the animated border wrapper