### PR TITLE
fix(compare): hide non-ready series in commit activity chart

### DIFF
--- a/src/app/compare/_components/commit-activity-comparison.tsx
+++ b/src/app/compare/_components/commit-activity-comparison.tsx
@@ -157,36 +157,64 @@ export function CommitActivityComparison({
                 tick={{ fontSize: 12 }}
               />
               <ChartTooltip content={<ChartTooltipContent />} />
-              <Line
-                type="monotone"
-                dataKey="commitsA"
-                stroke="var(--color-commitsA)"
-                strokeWidth={2}
-                dot={false}
-              />
-              <Line
-                type="monotone"
-                dataKey="commitsB"
-                stroke="var(--color-commitsB)"
-                strokeWidth={2}
-                dot={false}
-              />
+              {readyA && (
+                <Line
+                  type="monotone"
+                  dataKey="commitsA"
+                  stroke="var(--color-commitsA)"
+                  strokeWidth={2}
+                  dot={false}
+                />
+              )}
+              {readyB && (
+                <Line
+                  type="monotone"
+                  dataKey="commitsB"
+                  stroke="var(--color-commitsB)"
+                  strokeWidth={2}
+                  dot={false}
+                />
+              )}
             </LineChart>
           </ChartContainer>
           <div className="flex items-center justify-center gap-6 mt-3 text-xs text-muted-foreground">
             <div className="flex items-center gap-1.5">
               <div
                 className="size-2.5 rounded-full"
-                style={{ backgroundColor: "var(--chart-1)" }}
+                style={{
+                  backgroundColor: readyA
+                    ? "var(--chart-1)"
+                    : "var(--muted-foreground)",
+                  opacity: readyA ? 1 : 0.4,
+                }}
               />
-              {runA.repository.fullName}
+              <span>
+                {runA.repository.fullName}
+                {!readyA && (
+                  <span className="ml-1 text-muted-foreground/60">
+                    {`(${activityA?.state === "pending" ? "loading" : "unavailable"})`}
+                  </span>
+                )}
+              </span>
             </div>
             <div className="flex items-center gap-1.5">
               <div
                 className="size-2.5 rounded-full"
-                style={{ backgroundColor: "var(--chart-2)" }}
+                style={{
+                  backgroundColor: readyB
+                    ? "var(--chart-2)"
+                    : "var(--muted-foreground)",
+                  opacity: readyB ? 1 : 0.4,
+                }}
               />
-              {runB.repository.fullName}
+              <span>
+                {runB.repository.fullName}
+                {!readyB && (
+                  <span className="ml-1 text-muted-foreground/60">
+                    {`(${activityB?.state === "pending" ? "loading" : "unavailable"})`}
+                  </span>
+                )}
+              </span>
             </div>
           </div>
         </CardContent>


### PR DESCRIPTION
## Summary

- Omit chart lines for repos with pending/failed commit activity instead of rendering misleading zero lines
- Annotate legend entries with "(loading)" or "(unavailable)" status for non-ready repos
- Preserve existing placeholder card when neither repo is ready

Closes #68

## Test plan

- [ ] Compare two repos where both have ready commit activity — both lines render normally
- [ ] Compare two repos where one has pending commit activity — only the ready repo's line renders; legend shows "(loading)" for the other
- [ ] Compare two repos where one has failed commit activity — only the ready repo's line renders; legend shows "(unavailable)" for the other
- [ ] Compare two repos where neither has ready data — placeholder card displays as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced commit activity comparison with visual status indicators showing when data is loading or unavailable.
  * Added status badges next to repository names to reflect data readiness state.
  * Updated legend color swatches to visually indicate when comparison data is ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->