### PR TITLE
fix(compare): improve content, labels, and UX

### DIFF
--- a/src/app/compare/_components/commit-activity-comparison.tsx
+++ b/src/app/compare/_components/commit-activity-comparison.tsx
@@ -70,7 +70,7 @@ export function CommitActivityComparison({
         <Card>
           <CardHeader>
             <CardTitle className="text-sm font-medium">
-              Commit Activity
+              Commit Activity (past year)
             </CardTitle>
           </CardHeader>
           <CardContent>
@@ -102,7 +102,7 @@ export function CommitActivityComparison({
         <Card>
           <CardHeader>
             <CardTitle className="text-sm font-medium">
-              Commit Activity
+              Commit Activity (past year)
             </CardTitle>
           </CardHeader>
           <CardContent>
@@ -133,7 +133,9 @@ export function CommitActivityComparison({
     <Container>
       <Card>
         <CardHeader>
-          <CardTitle className="text-sm font-medium">Commit Activity</CardTitle>
+          <CardTitle className="text-sm font-medium">
+            Commit Activity (past year)
+          </CardTitle>
         </CardHeader>
         <CardContent>
           <ChartContainer

--- a/src/app/compare/_components/compare-form.tsx
+++ b/src/app/compare/_components/compare-form.tsx
@@ -97,7 +97,7 @@ export function CompareForm({ initialA, initialB }: CompareFormProps) {
             type="text"
             name="a"
             id="compare-input-a"
-            placeholder="owner/repository"
+            placeholder="GitHub URL or owner/repository"
             required
             maxLength={200}
             autoComplete="off"
@@ -131,7 +131,7 @@ export function CompareForm({ initialA, initialB }: CompareFormProps) {
             type="text"
             name="b"
             id="compare-input-b"
-            placeholder="owner/repository"
+            placeholder="GitHub URL or owner/repository"
             required
             maxLength={200}
             autoComplete="off"

--- a/src/app/compare/_components/compare-header.tsx
+++ b/src/app/compare/_components/compare-header.tsx
@@ -1,5 +1,6 @@
 import { Code2, ExternalLink, GitFork, Scale, Star } from "lucide-react";
 import Image from "next/image";
+import Link from "next/link";
 import { Container } from "@/components/container";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
@@ -100,6 +101,12 @@ function ProjectCard({ run }: { run: AnalysisRun }) {
                 {result.category}
               </Badge>
             </div>
+            <Link
+              href={`/p/${run.repository.owner}/${run.repository.name}`}
+              className="text-xs text-muted-foreground hover:underline"
+            >
+              View full analysis &rarr;
+            </Link>
           </>
         )}
       </CardContent>

--- a/src/app/compare/_components/comparison-table.tsx
+++ b/src/app/compare/_components/comparison-table.tsx
@@ -1,6 +1,4 @@
-"use client";
-
-import { format, formatDistanceToNow } from "date-fns";
+import { format } from "date-fns";
 import { Container } from "@/components/container";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { AnalysisRun } from "@/lib/domain/assessment";
@@ -12,7 +10,7 @@ interface ComparisonTableProps {
 }
 
 type BetterDirection = "higher" | "lower" | "newer";
-type Section = "freshness" | "engagement" | "health" | "activity";
+type Section = "freshness" | "health" | "activity";
 
 interface MetricRow {
   label: string;
@@ -27,7 +25,7 @@ interface MetricRow {
 function formatDate(iso: string | null): string {
   if (!iso) return "N/A";
   const d = new Date(iso);
-  return `${format(d, "MMM d, yyyy")} (${formatDistanceToNow(d, { addSuffix: true })})`;
+  return format(d, "MMM d, yyyy");
 }
 
 function fmtCount(val: number | null): string {
@@ -125,25 +123,7 @@ function buildRows(runA: AnalysisRun, runB: AnalysisRun): MetricRow[] {
       better: "newer",
     },
     {
-      label: "Stars",
-      section: "engagement",
-      valueA: fmtCount(mA?.stars ?? null),
-      valueB: fmtCount(mB?.stars ?? null),
-      rawA: mA?.stars ?? null,
-      rawB: mB?.stars ?? null,
-      better: "higher",
-    },
-    {
-      label: "Forks",
-      section: "engagement",
-      valueA: fmtCount(mA?.forks ?? null),
-      valueB: fmtCount(mB?.forks ?? null),
-      rawA: mA?.forks ?? null,
-      rawB: mB?.forks ?? null,
-      better: "higher",
-    },
-    {
-      label: "Open Issues %",
+      label: "Open Issue Ratio",
       section: "health",
       valueA: fmtPercent(mA?.openIssuesPercent ?? null),
       valueB: fmtPercent(mB?.openIssuesPercent ?? null),
@@ -152,7 +132,7 @@ function buildRows(runA: AnalysisRun, runB: AnalysisRun): MetricRow[] {
       better: "lower",
     },
     {
-      label: "Resolution Time",
+      label: "Median Resolution Time",
       section: "health",
       valueA: fmtDays(mA?.medianIssueResolutionDays ?? null),
       valueB: fmtDays(mB?.medianIssueResolutionDays ?? null),
@@ -223,7 +203,6 @@ export function ComparisonTable({ runA, runB }: ComparisonTableProps) {
 
   const sections: { title: string; key: Section }[] = [
     { title: "Activity Freshness", key: "freshness" },
-    { title: "Engagement", key: "engagement" },
     { title: "Health", key: "health" },
     { title: "Activity Volume", key: "activity" },
   ];

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -136,7 +136,8 @@ async function CachedComparePage({
               Compare Projects
             </h1>
             <p className="text-sm text-muted-foreground">
-              Evaluate two GitHub repositories side-by-side.
+              Compare maintenance scores, activity, and health metrics for two
+              repositories.
             </p>
           </div>
           <CompareForm initialA={a} initialB={b} />
@@ -146,8 +147,8 @@ async function CachedComparePage({
       {isSameProject && (
         <Container className="py-2">
           <p className="text-sm text-muted-foreground">
-            Both sides point to the same project. Enter two different
-            repositories to compare.
+            Both fields refer to the same repository. Enter two different
+            projects to compare.
           </p>
         </Container>
       )}
@@ -168,7 +169,7 @@ async function CachedComparePage({
               : !runB && parsedB
                 ? `${parsedB.owner}/${parsedB.project} has not been analyzed yet. Use the form above to analyze it.`
                 : runA && runB && (!runA.metrics || !runB.metrics)
-                  ? "Analysis is in progress or incomplete. Try re-submitting the form."
+                  ? "Analysis is still in progress for one or both repositories. Try refreshing the page."
                   : "Enter two repositories above to compare them."}
           </p>
         </Container>


### PR DESCRIPTION
## Summary

- Update subtitle to match homepage's direct tone
- Fix misleading same-project and in-progress fallback messages
- Rename "Open Issues %" → "Open Issue Ratio", "Resolution Time" → "Median Resolution Time"
- Remove Stars/Forks from comparison table (already visible in header cards)
- Switch to absolute-only dates to prevent stale relative times on cached pages
- Drop `"use client"` from comparison table (no longer needed without `formatDistanceToNow`)
- Add "View full analysis →" link to header project cards
- Add "(past year)" to commit activity chart title
- Match compare form input placeholder to homepage format

Closes #64

## Test plan

- [ ] Visit `/compare` — verify updated subtitle and placeholder text
- [ ] Enter same repo in both fields — verify updated warning message
- [ ] Compare two repos — verify header cards show "View full analysis →" links
- [ ] Verify comparison table has no Stars/Forks section
- [ ] Verify "Open Issue Ratio" and "Median Resolution Time" labels
- [ ] Verify dates are absolute-only (no relative suffix)
- [ ] Verify chart title says "Commit Activity (past year)"
- [ ] Run `bun run build` — confirm comparison table renders as server component