### PR TITLE
refactor(ui): extract shared RepositoryStats component

### DIFF
--- a/src/app/compare/_components/compare-header.tsx
+++ b/src/app/compare/_components/compare-header.tsx
@@ -1,14 +1,12 @@
-import { Code2, ExternalLink, GitFork, Scale, Star } from "lucide-react";
-import Image from "next/image";
 import Link from "next/link";
 import { Container } from "@/components/container";
+import { RepositoryStats } from "@/components/repository-stats";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { computeScoreFromMetrics } from "@/core/maintenance";
 import { categoryColors } from "@/lib/category-styles";
 import type { AnalysisRun } from "@/lib/domain/assessment";
-import { formatNumber } from "@/lib/utils";
 
 interface CompareHeaderProps {
   runA: AnalysisRun;
@@ -19,71 +17,10 @@ function ProjectCard({ run }: { run: AnalysisRun }) {
   const metrics = run.metrics;
   const result = metrics ? computeScoreFromMetrics(metrics) : null;
 
-  const stats = [
-    {
-      icon: Star,
-      value: formatNumber(metrics?.stars ?? 0),
-      label: "Stars",
-    },
-    {
-      icon: GitFork,
-      value: formatNumber(metrics?.forks ?? 0),
-      label: "Forks",
-    },
-    { icon: Scale, value: metrics?.license, label: "License" },
-    { icon: Code2, value: metrics?.language, label: "Language" },
-  ].filter((s) => s.value);
-
   return (
     <Card className="flex-1 min-w-0">
       <CardContent className="space-y-3">
-        <div className="flex items-center gap-3 min-w-0">
-          {metrics?.avatarUrl && (
-            <Image
-              src={metrics.avatarUrl}
-              alt={`${run.repository.owner} avatar`}
-              width={32}
-              height={32}
-              className="rounded-full shrink-0"
-            />
-          )}
-          {metrics?.htmlUrl ? (
-            <a
-              href={metrics.htmlUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="group flex items-center gap-1.5 font-bold tracking-tight truncate hover:underline text-lg"
-            >
-              <span className="truncate">{run.repository.fullName}</span>
-              <ExternalLink className="size-3.5 opacity-0 transition-opacity group-hover:opacity-70 shrink-0" />
-            </a>
-          ) : (
-            <p className="font-bold tracking-tight truncate text-lg">
-              {run.repository.fullName}
-            </p>
-          )}
-        </div>
-
-        {metrics?.description && (
-          <p className="text-sm text-muted-foreground line-clamp-2">
-            {metrics.description}
-          </p>
-        )}
-
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-sm text-muted-foreground">
-          {stats.map((stat) => (
-            <div
-              key={stat.label}
-              className="flex items-center gap-1"
-              title={stat.label}
-            >
-              <stat.icon className="size-3.5 opacity-70" />
-              <span className="font-medium text-foreground/80">
-                {stat.value}
-              </span>
-            </div>
-          ))}
-        </div>
+        <RepositoryStats run={run} size="compact" />
 
         {result && (
           <>

--- a/src/app/p/[owner]/[project]/_components/project-info.tsx
+++ b/src/app/p/[owner]/[project]/_components/project-info.tsx
@@ -1,16 +1,8 @@
-import {
-  Calendar,
-  Code2,
-  ExternalLink,
-  GitFork,
-  Scale,
-  Star,
-} from "lucide-react";
-import Image from "next/image";
+import { Calendar } from "lucide-react";
 import { Suspense } from "react";
 import { RelativeTime } from "@/components/relative-time";
+import { RepositoryStats } from "@/components/repository-stats";
 import type { AnalysisRun } from "@/lib/domain/assessment";
-import { formatNumber } from "@/lib/utils";
 import { ProjectActions } from "./project-actions";
 
 interface ProjectInfoProps {
@@ -20,86 +12,21 @@ interface ProjectInfoProps {
 export function ProjectInfo({ run }: ProjectInfoProps) {
   const metrics = run.metrics;
 
-  const stats = [
-    {
-      icon: Star,
-      value: formatNumber(metrics?.stars ?? 0),
-      label: "Stars",
-    },
-    {
-      icon: GitFork,
-      value: formatNumber(metrics?.forks ?? 0),
-      label: "Forks",
-    },
-    { icon: Scale, value: metrics?.license, label: "License" },
-    { icon: Code2, value: metrics?.language, label: "Language" },
-  ].filter((s) => s.value);
-
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex items-center gap-3">
-          {metrics?.avatarUrl && (
-            <Image
-              src={metrics.avatarUrl}
-              alt={`${run.repository.owner} avatar`}
-              width={40}
-              height={40}
-              className="rounded-full"
-            />
-          )}
-          {metrics?.htmlUrl ? (
-            <a
-              href={metrics.htmlUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="group flex items-center gap-2 text-2xl sm:text-3xl font-bold tracking-tight hover:underline"
-            >
-              <span>{run.repository.fullName}</span>
-              <ExternalLink className="size-4 opacity-0 transition-opacity group-hover:opacity-70" />
-            </a>
-          ) : (
-            <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">
-              {run.repository.fullName}
-            </h1>
-          )}
-        </div>
-        <ProjectActions run={run} />
-      </div>
-
-      {metrics?.description && (
-        <p className="text-base text-muted-foreground leading-relaxed">
-          {metrics.description}
-        </p>
-      )}
-
-      <div className="flex flex-wrap items-center gap-x-5 gap-y-2.5 pt-2 text-sm text-muted-foreground">
-        {stats.map((stat) => (
-          <div
-            key={stat.label}
-            className="flex items-center gap-1.5"
-            title={stat.label}
+    <RepositoryStats run={run} trailing={<ProjectActions run={run} />}>
+      {metrics?.repositoryCreatedAt && (
+        <div className="flex items-center gap-1.5" title="Created">
+          <Calendar className="size-4 opacity-70" />
+          <Suspense
+            fallback={<span className="font-medium text-foreground/80">—</span>}
           >
-            <stat.icon className="size-4 opacity-70" />
-            <span className="font-medium text-foreground/80">{stat.value}</span>
-          </div>
-        ))}
-        {metrics?.repositoryCreatedAt && (
-          <div className="flex items-center gap-1.5" title="Created">
-            <Calendar className="size-4 opacity-70" />
-            <Suspense
-              fallback={
-                <span className="font-medium text-foreground/80">—</span>
-              }
-            >
-              <RelativeTime
-                date={metrics.repositoryCreatedAt}
-                className="font-medium text-foreground/80"
-              />
-            </Suspense>
-          </div>
-        )}
-      </div>
-    </div>
+            <RelativeTime
+              date={metrics.repositoryCreatedAt}
+              className="font-medium text-foreground/80"
+            />
+          </Suspense>
+        </div>
+      )}
+    </RepositoryStats>
   );
 }

--- a/src/components/repository-stats.tsx
+++ b/src/components/repository-stats.tsx
@@ -1,0 +1,126 @@
+import { Code2, ExternalLink, GitFork, Scale, Star } from "lucide-react";
+import Image from "next/image";
+import type { AnalysisRun } from "@/lib/domain/assessment";
+import { formatNumber } from "@/lib/utils";
+
+const sizeConfig = {
+  default: {
+    avatar: 40,
+    wrapper: "space-y-4",
+    headerRow: "flex items-center gap-3",
+    linkClass:
+      "group flex items-center gap-2 text-2xl sm:text-3xl font-bold tracking-tight hover:underline",
+    nameClass: "",
+    fallbackTag: "h1" as const,
+    fallbackClass: "text-2xl sm:text-3xl font-bold tracking-tight",
+    externalIcon: "size-4 opacity-0 transition-opacity group-hover:opacity-70",
+    description: "text-base text-muted-foreground leading-relaxed",
+    statsRow:
+      "flex flex-wrap items-center gap-x-5 gap-y-2.5 pt-2 text-sm text-muted-foreground",
+    statItem: "flex items-center gap-1.5",
+    statIcon: "size-4 opacity-70",
+  },
+  compact: {
+    avatar: 32,
+    wrapper: "space-y-3",
+    headerRow: "flex items-center gap-3 min-w-0",
+    linkClass:
+      "group flex items-center gap-1.5 font-bold tracking-tight truncate hover:underline text-lg",
+    nameClass: "truncate",
+    fallbackTag: "p" as const,
+    fallbackClass: "font-bold tracking-tight truncate text-lg",
+    externalIcon:
+      "size-3.5 opacity-0 transition-opacity group-hover:opacity-70 shrink-0",
+    description: "text-sm text-muted-foreground line-clamp-2",
+    statsRow:
+      "flex flex-wrap items-center gap-x-4 gap-y-1.5 text-sm text-muted-foreground",
+    statItem: "flex items-center gap-1",
+    statIcon: "size-3.5 opacity-70",
+  },
+} as const;
+
+interface RepositoryStatsProps {
+  run: AnalysisRun;
+  size?: "default" | "compact";
+  trailing?: React.ReactNode;
+  children?: React.ReactNode;
+}
+
+export function RepositoryStats({
+  run,
+  size = "default",
+  trailing,
+  children,
+}: RepositoryStatsProps) {
+  const metrics = run.metrics;
+  const cfg = sizeConfig[size];
+
+  const stats = [
+    {
+      icon: Star,
+      value: formatNumber(metrics?.stars ?? 0),
+      label: "Stars",
+    },
+    {
+      icon: GitFork,
+      value: formatNumber(metrics?.forks ?? 0),
+      label: "Forks",
+    },
+    { icon: Scale, value: metrics?.license, label: "License" },
+    { icon: Code2, value: metrics?.language, label: "Language" },
+  ].filter((s) => s.value);
+
+  const FallbackTag = cfg.fallbackTag;
+
+  return (
+    <div data-slot="repository-stats" className={cfg.wrapper}>
+      <div
+        className={
+          trailing ? "flex items-center justify-between gap-3" : undefined
+        }
+      >
+        <div className={cfg.headerRow}>
+          {metrics?.avatarUrl && (
+            <Image
+              src={metrics.avatarUrl}
+              alt={`${run.repository.owner} avatar`}
+              width={cfg.avatar}
+              height={cfg.avatar}
+              className={`rounded-full${size === "compact" ? " shrink-0" : ""}`}
+            />
+          )}
+          {metrics?.htmlUrl ? (
+            <a
+              href={metrics.htmlUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={cfg.linkClass}
+            >
+              <span className={cfg.nameClass}>{run.repository.fullName}</span>
+              <ExternalLink className={cfg.externalIcon} />
+            </a>
+          ) : (
+            <FallbackTag className={cfg.fallbackClass}>
+              {run.repository.fullName}
+            </FallbackTag>
+          )}
+        </div>
+        {trailing}
+      </div>
+
+      {metrics?.description && (
+        <p className={cfg.description}>{metrics.description}</p>
+      )}
+
+      <div className={cfg.statsRow}>
+        {stats.map((stat) => (
+          <div key={stat.label} className={cfg.statItem} title={stat.label}>
+            <stat.icon className={cfg.statIcon} />
+            <span className="font-medium text-foreground/80">{stat.value}</span>
+          </div>
+        ))}
+        {children}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract shared `RepositoryStats` component from duplicated code in the project detail page and compare page
- Support `size` variants (`default` / `compact`) for visual differences between contexts
- Add `trailing` and `children` slots for context-specific content (ProjectActions, Calendar)

## Test plan
- [x] `bun run check-types` passes
- [x] `bun run lint` passes
- [x] `bun run test` — all 70 tests pass
- [ ] Visual check: project detail page renders identically
- [ ] Visual check: compare page renders identically

Closes #66