### PR TITLE
fix(build): wrap generateMetadata fetchQuery with "use cache"

### DIFF
--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -22,6 +22,12 @@ function normalizeSlug(raw: string | undefined) {
   return { slug: `${owner}/${project}`, owner, project };
 }
 
+async function cachedCompareMetadata(owner: string, project: string) {
+  "use cache";
+  cacheLife("hours");
+  return fetchQuery(api.analysisRuns.getByRepositorySlug, { owner, project });
+}
+
 export async function generateMetadata({
   searchParams,
 }: {
@@ -44,14 +50,8 @@ export async function generateMetadata({
   let runB = null;
   try {
     [runA, runB] = await Promise.all([
-      fetchQuery(api.analysisRuns.getByRepositorySlug, {
-        owner: normA.owner,
-        project: normA.project,
-      }),
-      fetchQuery(api.analysisRuns.getByRepositorySlug, {
-        owner: normB.owner,
-        project: normB.project,
-      }),
+      cachedCompareMetadata(normA.owner, normA.project),
+      cachedCompareMetadata(normB.owner, normB.project),
     ]);
   } catch {
     return {

--- a/src/components/relative-time.tsx
+++ b/src/components/relative-time.tsx
@@ -15,18 +15,16 @@ export function RelativeTime({
   className,
 }: RelativeTimeProps) {
   const [value, setValue] = useState(() =>
-    formatDistanceToNow(
-      typeof date === "string" ? new Date(date) : date,
-      { addSuffix },
-    ),
+    formatDistanceToNow(typeof date === "string" ? new Date(date) : date, {
+      addSuffix,
+    }),
   );
 
   useEffect(() => {
     setValue(
-      formatDistanceToNow(
-        typeof date === "string" ? new Date(date) : date,
-        { addSuffix },
-      ),
+      formatDistanceToNow(typeof date === "string" ? new Date(date) : date, {
+        addSuffix,
+      }),
     );
   }, [date, addSuffix]);
 


### PR DESCRIPTION
## Summary

- Add `"use cache"` + `cacheLife()` wrappers around `fetchQuery` calls in `generateMetadata` for the project layout and compare page
- Fixes prerender error caused by Convex's `fetchQuery` hardcoding `cache: "no-store"` when `cacheComponents` is enabled

## Test plan

- [x] `bun run check-types` passes
- [x] `bun run build` succeeds with no prerender errors
- [x] Both `/p/[owner]/[project]` and `/compare` routes show as Partial Prerender

Closes #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Implemented intelligent caching mechanisms for repository analysis and project metadata, improving data retrieval performance and reducing load times across analysis and comparison features.
  * Enhanced component code structure and formatting for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->