### PR TITLE
feat(analysis): auto-refresh stale data on project page visit

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,10 +18,12 @@
         "date-fns": "^4.1.0",
         "lucide-react": "^0.562.0",
         "next": "16.1.1",
+        "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "recharts": "2.15.4",
+        "sonner": "^2.0.7",
         "streamdown": "^2.2.0",
         "tailwind-merge": "^3.4.0",
       },
@@ -803,6 +805,8 @@
 
     "next": ["next@16.1.1", "", { "dependencies": { "@next/env": "16.1.1", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.8.3", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.1.1", "@next/swc-darwin-x64": "16.1.1", "@next/swc-linux-arm64-gnu": "16.1.1", "@next/swc-linux-arm64-musl": "16.1.1", "@next/swc-linux-x64-gnu": "16.1.1", "@next/swc-linux-x64-musl": "16.1.1", "@next/swc-win32-arm64-msvc": "16.1.1", "@next/swc-win32-x64-msvc": "16.1.1", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w=="],
 
+    "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
+
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
@@ -874,6 +878,8 @@
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
+
+    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/convex/_shared/constants.ts
+++ b/convex/_shared/constants.ts
@@ -9,6 +9,8 @@ export const COMMIT_ACTIVITY_MAX_ATTEMPTS =
 
 export const ANALYSIS_FRESHNESS_MS = 60 * 60 * 24 * 3 * 1000;
 
+export const PAGE_VISIT_FRESHNESS_MS = 7 * 24 * 60 * 60 * 1000;
+
 export const COMMIT_ACTIVITY_DELAYED_RETRY_MS = 15 * 60 * 1000;
 
 export function isTerminalRunState(

--- a/convex/_shared/types.ts
+++ b/convex/_shared/types.ts
@@ -23,4 +23,5 @@ export type AnalysisRunTriggerSource =
   | "homepage"
   | "direct_visit"
   | "manual_refresh"
+  | "page_visit"
   | "system";

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -29,6 +29,7 @@ export const triggerSource = v.union(
   v.literal("homepage"),
   v.literal("direct_visit"),
   v.literal("manual_refresh"),
+  v.literal("page_visit"),
   v.literal("system"),
 );
 

--- a/package.json
+++ b/package.json
@@ -31,10 +31,12 @@
     "date-fns": "^4.1.0",
     "lucide-react": "^0.562.0",
     "next": "16.1.1",
+    "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "recharts": "2.15.4",
+    "sonner": "^2.0.7",
     "streamdown": "^2.2.0",
     "tailwind-merge": "^3.4.0"
   },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { ConvexClientProvider } from "@/components/convex-client-provider";
 import { DotBackground } from "@/components/dot-background";
 import { Footer } from "@/components/footer";
 import { Header } from "@/components/header";
+import { Toaster } from "@/components/ui/sonner";
 
 const ibmPlexSans = IBM_Plex_Sans({
   variable: "--font-ibm-plex-sans",
@@ -77,6 +78,7 @@ export default function RootLayout({
           <Header />
           <div className="flex-1">{children}</div>
           <Footer />
+          <Toaster position="bottom-right" />
         </ConvexClientProvider>
       </body>
     </html>

--- a/src/app/p/[owner]/[project]/_components/auto-refresh.tsx
+++ b/src/app/p/[owner]/[project]/_components/auto-refresh.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useMutation, useQuery } from "convex/react";
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import { isTerminalRunState } from "@/core/analysis/constants";
+import { api } from "../../../../../../convex/_generated/api";
+
+interface AutoRefreshProps {
+  owner: string;
+  project: string;
+}
+
+export function AutoRefresh({ owner, project }: AutoRefreshProps) {
+  const triggerRefresh = useMutation(api.analysisRuns.triggerRefreshIfStale);
+  const liveRun = useQuery(api.analysisRuns.getByRepositorySlug, {
+    owner,
+    project,
+  });
+
+  const didTriggerRef = useRef(false);
+  const toastIdRef = useRef<string | number | null>(null);
+  const runIdRef = useRef<string | null>(null);
+
+  // Trigger refresh on mount (ref guard for strict mode)
+  useEffect(() => {
+    if (!didTriggerRef.current) {
+      didTriggerRef.current = true;
+
+      triggerRefresh({ owner, project }).then(({ refreshTriggered, runId }) => {
+        if (refreshTriggered && runId) {
+          runIdRef.current = runId;
+          toastIdRef.current = toast.loading("Refreshing analysis data...");
+        }
+      });
+    }
+
+    return () => {
+      if (toastIdRef.current) {
+        toast.dismiss(toastIdRef.current);
+      }
+    };
+  }, [owner, project, triggerRefresh]);
+
+  // Dismiss toast when the triggered run reaches a terminal state
+  useEffect(() => {
+    if (!toastIdRef.current || !runIdRef.current || !liveRun) return;
+
+    if (
+      liveRun.id === runIdRef.current &&
+      isTerminalRunState(liveRun.runState)
+    ) {
+      toast.dismiss(toastIdRef.current);
+      toastIdRef.current = null;
+      runIdRef.current = null;
+    }
+  }, [liveRun]);
+
+  return null;
+}

--- a/src/app/p/[owner]/[project]/_components/auto-refresh.tsx
+++ b/src/app/p/[owner]/[project]/_components/auto-refresh.tsx
@@ -6,54 +6,45 @@ import { toast } from "sonner";
 import { isTerminalRunState } from "@/core/analysis/constants";
 import { api } from "../../../../../../convex/_generated/api";
 
-interface AutoRefreshProps {
+export function AutoRefresh({
+  owner,
+  project,
+}: {
   owner: string;
   project: string;
-}
-
-export function AutoRefresh({ owner, project }: AutoRefreshProps) {
+}) {
   const triggerRefresh = useMutation(api.analysisRuns.triggerRefreshIfStale);
   const liveRun = useQuery(api.analysisRuns.getByRepositorySlug, {
     owner,
     project,
   });
 
-  const lastTriggeredKeyRef = useRef<string | null>(null);
   const toastIdRef = useRef<string | number | null>(null);
   const runIdRef = useRef<string | null>(null);
 
   useEffect(() => {
-    const projectKey = `${owner}/${project}`;
     let cancelled = false;
 
-    if (lastTriggeredKeyRef.current !== projectKey) {
-      lastTriggeredKeyRef.current = projectKey;
-
-      triggerRefresh({ owner, project })
-        .then(({ refreshTriggered, runId }) => {
-          if (cancelled) return;
-          if (refreshTriggered && runId) {
-            runIdRef.current = runId;
-            toastIdRef.current = toast.loading("Refreshing analysis data...");
-          }
-        })
-        .catch(() => {});
-    }
+    triggerRefresh({ owner, project })
+      .then(({ refreshTriggered, runId }) => {
+        if (cancelled) return;
+        if (refreshTriggered && runId) {
+          runIdRef.current = runId;
+          toastIdRef.current = toast.loading("Refreshing analysis data...");
+        }
+      })
+      .catch(() => {});
 
     return () => {
       cancelled = true;
-      if (toastIdRef.current) {
-        toast.dismiss(toastIdRef.current);
-      }
+      if (toastIdRef.current) toast.dismiss(toastIdRef.current);
       toastIdRef.current = null;
       runIdRef.current = null;
     };
   }, [owner, project, triggerRefresh]);
 
-  // Dismiss toast when the triggered run reaches a terminal state
   useEffect(() => {
     if (!toastIdRef.current || !runIdRef.current || !liveRun) return;
-
     if (
       liveRun.id === runIdRef.current &&
       isTerminalRunState(liveRun.runState)

--- a/src/app/p/[owner]/[project]/_components/auto-refresh.tsx
+++ b/src/app/p/[owner]/[project]/_components/auto-refresh.tsx
@@ -39,6 +39,9 @@ export function AutoRefresh({ owner, project }: AutoRefreshProps) {
       if (toastIdRef.current) {
         toast.dismiss(toastIdRef.current);
       }
+      didTriggerRef.current = false;
+      toastIdRef.current = null;
+      runIdRef.current = null;
     };
   }, [owner, project, triggerRefresh]);
 

--- a/src/app/p/[owner]/[project]/page.tsx
+++ b/src/app/p/[owner]/[project]/page.tsx
@@ -2,6 +2,7 @@ import { fetchQuery } from "convex/nextjs";
 import { cacheLife } from "next/cache";
 import type { AnalysisRun } from "@/lib/domain/assessment";
 import { api } from "../../../../../convex/_generated/api";
+import { AutoRefresh } from "./_components/auto-refresh";
 import { CommitActivityLive } from "./_components/commit-activity-live";
 import { MaintenanceHealth } from "./_components/maintenance-health";
 import { NotAnalyzedError } from "./_components/not-analyzed-error";
@@ -51,5 +52,10 @@ export default async function ProjectPage({
   params: Promise<{ owner: string; project: string }>;
 }) {
   const { owner, project } = await params;
-  return <CachedProjectPage owner={owner} project={project} />;
+  return (
+    <>
+      <AutoRefresh owner={owner} project={project} />
+      <CachedProjectPage owner={owner} project={project} />
+    </>
+  );
 }

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react";
+import { useTheme } from "next-themes";
+import { Toaster as Sonner, type ToasterProps } from "sonner";
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme();
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  );
+};
+
+export { Toaster };

--- a/src/lib/domain/assessment.ts
+++ b/src/lib/domain/assessment.ts
@@ -41,6 +41,7 @@ export type AnalysisRunTriggerSource =
   | "homepage"
   | "direct_visit"
   | "manual_refresh"
+  | "page_visit"
   | "system";
 
 export interface MetricsSnapshot {


### PR DESCRIPTION
## Summary
- When users visit a project page with stale analysis data (>7 days), a background re-analysis is triggered automatically. Existing data stays visible while new results flow in via Convex subscriptions.
- Adds a `triggerRefreshIfStale` mutation with dedup logic (skips if a run is active or data is fresh), and an `executeAnalysis` internalAction extracted from the shared analysis pipeline.
- Shows a subtle loading toast (sonner) during refresh that auto-dismisses on completion. Handles strict mode, navigation cleanup, and concurrent visitors.

## Test plan
- [ ] Visit a project page with >7-day-old data → toast appears, auto-dismisses when analysis completes
- [ ] Visit a project page with <7-day-old data → no toast, no mutation side effects
- [ ] Visit a project page with an active analysis run → no duplicate run triggered
- [ ] Homepage search form still works as before (regression check — `analyzeProject` unchanged)
- [ ] Navigate away during a refresh → loading toast is dismissed
- [ ] `bun run check-types` — no type errors
- [ ] `bun run lint` — no lint issues
- [ ] `bun run build` — production build succeeds
- [ ] `bun run test` — all 75 tests pass

Closes #80.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-refresh runs are triggered when visiting a project page if data is older than 7 days.
  * Non-intrusive toast notifications indicate refresh start and completion, respecting the app theme.

* **Chores**
  * Added runtime support for themed toast notifications to enable the new UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->