### PR TITLE
feat(red-flags): detect and display risk signals on project page

### DIFF
--- a/src/app/p/[owner]/[project]/_components/project-info.tsx
+++ b/src/app/p/[owner]/[project]/_components/project-info.tsx
@@ -13,7 +13,8 @@ interface ProjectInfoProps {
 
 export function ProjectInfo({ run }: ProjectInfoProps) {
   const metrics = run.metrics;
-  const flags = metrics ? detectRedFlags(metrics) : [];
+  const analysisTime = new Date(run.completedAt ?? run.startedAt);
+  const flags = metrics ? detectRedFlags(metrics, analysisTime) : [];
 
   return (
     <div className="space-y-3">

--- a/src/app/p/[owner]/[project]/_components/project-info.tsx
+++ b/src/app/p/[owner]/[project]/_components/project-info.tsx
@@ -2,8 +2,10 @@ import { Calendar } from "lucide-react";
 import { Suspense } from "react";
 import { RelativeTime } from "@/components/relative-time";
 import { RepositoryStats } from "@/components/repository-stats";
+import { detectRedFlags } from "@/core/red-flags";
 import type { AnalysisRun } from "@/lib/domain/assessment";
 import { ProjectActions } from "./project-actions";
+import { RedFlagBadges } from "./red-flag-badges";
 
 interface ProjectInfoProps {
   run: AnalysisRun;
@@ -11,22 +13,28 @@ interface ProjectInfoProps {
 
 export function ProjectInfo({ run }: ProjectInfoProps) {
   const metrics = run.metrics;
+  const flags = metrics ? detectRedFlags(metrics) : [];
 
   return (
-    <RepositoryStats run={run} trailing={<ProjectActions run={run} />}>
-      {metrics?.repositoryCreatedAt && (
-        <div className="flex items-center gap-1.5" title="Created">
-          <Calendar className="size-4 opacity-70" />
-          <Suspense
-            fallback={<span className="font-medium text-foreground/80">—</span>}
-          >
-            <RelativeTime
-              date={metrics.repositoryCreatedAt}
-              className="font-medium text-foreground/80"
-            />
-          </Suspense>
-        </div>
-      )}
-    </RepositoryStats>
+    <div className="space-y-3">
+      <RepositoryStats run={run} trailing={<ProjectActions run={run} />}>
+        {metrics?.repositoryCreatedAt && (
+          <div className="flex items-center gap-1.5" title="Created">
+            <Calendar className="size-4 opacity-70" />
+            <Suspense
+              fallback={
+                <span className="font-medium text-foreground/80">—</span>
+              }
+            >
+              <RelativeTime
+                date={metrics.repositoryCreatedAt}
+                className="font-medium text-foreground/80"
+              />
+            </Suspense>
+          </div>
+        )}
+      </RepositoryStats>
+      <RedFlagBadges flags={flags} />
+    </div>
   );
 }

--- a/src/app/p/[owner]/[project]/_components/red-flag-badges.tsx
+++ b/src/app/p/[owner]/[project]/_components/red-flag-badges.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { AlertTriangle, OctagonAlert } from "lucide-react";
+import { badgeVariants } from "@/components/ui/badge";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import type { RedFlag } from "@/core/red-flags";
+import { cn } from "@/lib/utils";
+
+const severityConfig = {
+  critical: {
+    icon: OctagonAlert,
+    colors: "bg-destructive/15 text-destructive border-destructive/30",
+  },
+  warning: {
+    icon: AlertTriangle,
+    colors:
+      "bg-status-declining/15 text-status-declining border-status-declining/30",
+  },
+} as const;
+
+function RedFlagBadge({ flag }: { flag: RedFlag }) {
+  const config = severityConfig[flag.severity];
+  const Icon = config.icon;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            badgeVariants(),
+            "text-xs border cursor-pointer transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-ring/60 inline-flex items-center gap-1",
+            config.colors,
+          )}
+          aria-label={`Show details: ${flag.title}`}
+        >
+          <Icon className="size-3 opacity-80" aria-hidden="true" />
+          {flag.title}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-80 max-w-[calc(100vw-2rem)] bg-surface-2 space-y-2"
+      >
+        <p className="text-sm font-semibold">{flag.title}</p>
+        <p className="text-sm text-muted-foreground">{flag.description}</p>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export function RedFlagBadges({ flags }: { flags: RedFlag[] }) {
+  if (flags.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {flags.map((flag) => (
+        <RedFlagBadge key={flag.id} flag={flag} />
+      ))}
+    </div>
+  );
+}

--- a/src/core/red-flags/index.ts
+++ b/src/core/red-flags/index.ts
@@ -1,0 +1,3 @@
+export { detectRedFlags } from "./red-flags";
+export { RED_FLAGS_THRESHOLDS } from "./red-flags-config";
+export type { RedFlag, RedFlagId, RedFlagSeverity } from "./types";

--- a/src/core/red-flags/red-flags-config.ts
+++ b/src/core/red-flags/red-flags-config.ts
@@ -16,4 +16,7 @@ export const RED_FLAGS_THRESHOLDS = {
 
   /** Minimum commits in last 365 days for "no releases ever" */
   noReleasesEverMinCommits: 10,
+
+  /** Days within which a closed issue counts as "recent" activity */
+  recentIssueActivityDays: 365,
 } as const;

--- a/src/core/red-flags/red-flags-config.ts
+++ b/src/core/red-flags/red-flags-config.ts
@@ -1,0 +1,19 @@
+export const RED_FLAGS_THRESHOLDS = {
+  /** Days of no meaningful activity before triggering extended inactivity */
+  extendedInactivityDays: 180,
+
+  /** Minimum commits in last 90 days to consider "active commits" */
+  activeCommitsThreshold: 5,
+
+  /** Days since last release to consider "no release despite active commits" */
+  noRecentReleaseDays: 180,
+
+  /** Minimum open PRs to consider the stale PR check */
+  stalePrsMinOpen: 3,
+
+  /** Minimum age in years for "no releases ever" to be meaningful */
+  noReleasesEverMinAgeYears: 1,
+
+  /** Minimum commits in last 365 days for "no releases ever" */
+  noReleasesEverMinCommits: 10,
+} as const;

--- a/src/core/red-flags/red-flags.test.ts
+++ b/src/core/red-flags/red-flags.test.ts
@@ -1,0 +1,439 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MetricsSnapshot } from "@/lib/domain/assessment";
+import { detectRedFlags } from "./red-flags";
+
+const NOW = new Date("2026-02-13T00:00:00.000Z");
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function daysAgo(days: number): string {
+  return new Date(NOW.getTime() - days * DAY_MS).toISOString();
+}
+
+function makeSnapshot(
+  overrides: Partial<MetricsSnapshot> = {},
+): MetricsSnapshot {
+  return {
+    description: "A test repo",
+    stars: 700,
+    forks: 100,
+    avatarUrl: "",
+    htmlUrl: "",
+    license: "MIT",
+    language: "TypeScript",
+    repositoryCreatedAt: "2020-01-01T00:00:00.000Z",
+    isArchived: false,
+    lastCommitAt: daysAgo(3),
+    lastReleaseAt: daysAgo(30),
+    lastClosedIssueAt: daysAgo(10),
+    lastMergedPrAt: daysAgo(5),
+    openIssuesPercent: 20,
+    openIssuesCount: 20,
+    closedIssuesCount: 80,
+    medianIssueResolutionDays: 9,
+    openPrsCount: 3,
+    issuesCreatedLastYear: 14,
+    commitsLast90Days: 10,
+    mergedPrsLast90Days: 6,
+    releases: [
+      {
+        tagName: "v1.0.0",
+        name: "v1.0.0",
+        publishedAt: daysAgo(30),
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function hasFlag(snapshot: MetricsSnapshot, id: string): boolean {
+  return detectRedFlags(snapshot).some((f) => f.id === id);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("detectRedFlags", () => {
+  describe("healthy repository", () => {
+    it("returns no flags for a well-maintained repo", () => {
+      expect(detectRedFlags(makeSnapshot())).toHaveLength(0);
+    });
+  });
+
+  describe("archived_repository", () => {
+    it("flags archived repositories as critical", () => {
+      const flags = detectRedFlags(makeSnapshot({ isArchived: true }));
+      const flag = flags.find((f) => f.id === "archived_repository");
+      expect(flag).toBeDefined();
+      expect(flag?.severity).toBe("critical");
+    });
+
+    it("does not flag non-archived repositories", () => {
+      expect(
+        hasFlag(makeSnapshot({ isArchived: false }), "archived_repository"),
+      ).toBe(false);
+    });
+  });
+
+  describe("extended_inactivity", () => {
+    it("flags repos with no activity for 180+ days as critical", () => {
+      const flags = detectRedFlags(
+        makeSnapshot({
+          lastCommitAt: daysAgo(200),
+          lastMergedPrAt: daysAgo(250),
+          lastReleaseAt: daysAgo(300),
+        }),
+      );
+      const flag = flags.find((f) => f.id === "extended_inactivity");
+      expect(flag).toBeDefined();
+      expect(flag?.severity).toBe("critical");
+    });
+
+    it("does not flag repos with recent commits", () => {
+      expect(
+        hasFlag(
+          makeSnapshot({
+            lastCommitAt: daysAgo(10),
+            lastMergedPrAt: daysAgo(200),
+            lastReleaseAt: daysAgo(300),
+          }),
+          "extended_inactivity",
+        ),
+      ).toBe(false);
+    });
+
+    it("does not flag when all activity dates are null", () => {
+      expect(
+        hasFlag(
+          makeSnapshot({
+            lastCommitAt: null,
+            lastMergedPrAt: null,
+            lastReleaseAt: null,
+          }),
+          "extended_inactivity",
+        ),
+      ).toBe(false);
+    });
+
+    it("uses the most recent of all activity dates", () => {
+      // Most recent is 100 days ago (< 180 threshold)
+      expect(
+        hasFlag(
+          makeSnapshot({
+            lastCommitAt: daysAgo(100),
+            lastMergedPrAt: daysAgo(300),
+            lastReleaseAt: daysAgo(400),
+          }),
+          "extended_inactivity",
+        ),
+      ).toBe(false);
+    });
+
+    it("fires at exactly 180 days", () => {
+      expect(
+        hasFlag(
+          makeSnapshot({
+            lastCommitAt: daysAgo(180),
+            lastMergedPrAt: null,
+            lastReleaseAt: null,
+          }),
+          "extended_inactivity",
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("no_release_despite_commits", () => {
+    it("flags active repos with no recent release", () => {
+      expect(
+        hasFlag(
+          makeSnapshot({
+            commitsLast90Days: 20,
+            lastReleaseAt: daysAgo(200),
+            releases: [
+              { tagName: "v0.1.0", name: null, publishedAt: daysAgo(200) },
+            ],
+          }),
+          "no_release_despite_commits",
+        ),
+      ).toBe(true);
+    });
+
+    it("flags active repos that have never released", () => {
+      expect(
+        hasFlag(
+          makeSnapshot({
+            commitsLast90Days: 20,
+            lastReleaseAt: null,
+            releases: [],
+          }),
+          "no_release_despite_commits",
+        ),
+      ).toBe(true);
+    });
+
+    it("does not flag repos with recent releases", () => {
+      expect(
+        hasFlag(
+          makeSnapshot({
+            commitsLast90Days: 20,
+            lastReleaseAt: daysAgo(30),
+          }),
+          "no_release_despite_commits",
+        ),
+      ).toBe(false);
+    });
+
+    it("does not flag repos with few commits", () => {
+      expect(
+        hasFlag(
+          makeSnapshot({
+            commitsLast90Days: 2,
+            lastReleaseAt: daysAgo(200),
+          }),
+          "no_release_despite_commits",
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("stale_pull_requests", () => {
+    it("flags repos with open PRs and zero merges in 90 days", () => {
+      expect(
+        hasFlag(
+          makeSnapshot({
+            openPrsCount: 5,
+            mergedPrsLast90Days: 0,
+          }),
+          "stale_pull_requests",
+        ),
+      ).toBe(true);
+    });
+
+    it("does not flag repos with any recent merges", () => {
+      expect(
+        hasFlag(
+          makeSnapshot({
+            openPrsCount: 20,
+            mergedPrsLast90Days: 1,
+          }),
+          "stale_pull_requests",
+        ),
+      ).toBe(false);
+    });
+
+    it("does not flag repos with fewer than 3 open PRs", () => {
+      expect(
+        hasFlag(
+          makeSnapshot({
+            openPrsCount: 2,
+            mergedPrsLast90Days: 0,
+          }),
+          "stale_pull_requests",
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("no_issues_activity", () => {
+    it("flags active repos with zero issue tracker usage", () => {
+      expect(
+        hasFlag(
+          makeSnapshot({
+            issuesCreatedLastYear: 0,
+            closedIssuesCount: 0,
+            openIssuesCount: 0,
+            commitsLast90Days: 10,
+          }),
+          "no_issues_activity",
+        ),
+      ).toBe(true);
+    });
+
+    it("does not flag repos with any issue activity", () => {
+      expect(
+        hasFlag(
+          makeSnapshot({
+            issuesCreatedLastYear: 5,
+            closedIssuesCount: 3,
+            openIssuesCount: 2,
+          }),
+          "no_issues_activity",
+        ),
+      ).toBe(false);
+    });
+
+    it("does not flag inactive repos with no issues", () => {
+      expect(
+        hasFlag(
+          makeSnapshot({
+            issuesCreatedLastYear: 0,
+            closedIssuesCount: 0,
+            openIssuesCount: 0,
+            commitsLast90Days: 1,
+          }),
+          "no_issues_activity",
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("no_releases_ever", () => {
+    it("flags mature active repos that never released", () => {
+      expect(
+        hasFlag(
+          makeSnapshot({
+            releases: [],
+            repositoryCreatedAt: "2020-01-01T00:00:00.000Z",
+            commitsLast365Days: 50,
+          }),
+          "no_releases_ever",
+        ),
+      ).toBe(true);
+    });
+
+    it("does not flag young repos", () => {
+      expect(
+        hasFlag(
+          makeSnapshot({
+            releases: [],
+            repositoryCreatedAt: daysAgo(100),
+            commitsLast365Days: 50,
+          }),
+          "no_releases_ever",
+        ),
+      ).toBe(false);
+    });
+
+    it("does not flag repos with releases", () => {
+      expect(
+        hasFlag(
+          makeSnapshot({
+            releases: [
+              { tagName: "v1.0.0", name: null, publishedAt: daysAgo(30) },
+            ],
+          }),
+          "no_releases_ever",
+        ),
+      ).toBe(false);
+    });
+
+    it("does not flag inactive repos without releases", () => {
+      expect(
+        hasFlag(
+          makeSnapshot({
+            releases: [],
+            repositoryCreatedAt: "2020-01-01T00:00:00.000Z",
+            commitsLast365Days: 2,
+          }),
+          "no_releases_ever",
+        ),
+      ).toBe(false);
+    });
+
+    it("estimates yearly commits from 90-day count when 365-day data is missing", () => {
+      expect(
+        hasFlag(
+          makeSnapshot({
+            releases: [],
+            repositoryCreatedAt: "2020-01-01T00:00:00.000Z",
+            commitsLast90Days: 5,
+            commitsLast365Days: undefined,
+          }),
+          "no_releases_ever",
+        ),
+      ).toBe(true); // 5 * 4 = 20 >= 10
+    });
+  });
+
+  describe("multiple flags", () => {
+    it("returns multiple flags when several conditions are met", () => {
+      const flags = detectRedFlags(
+        makeSnapshot({
+          isArchived: true,
+          lastCommitAt: daysAgo(200),
+          lastMergedPrAt: daysAgo(250),
+          lastReleaseAt: daysAgo(300),
+        }),
+      );
+      expect(flags.length).toBeGreaterThanOrEqual(2);
+      expect(flags.some((f) => f.id === "archived_repository")).toBe(true);
+      expect(flags.some((f) => f.id === "extended_inactivity")).toBe(true);
+    });
+
+    it("returns critical flags alongside warning flags", () => {
+      const flags = detectRedFlags(
+        makeSnapshot({
+          lastCommitAt: daysAgo(200),
+          lastMergedPrAt: daysAgo(200),
+          lastReleaseAt: daysAgo(200),
+          commitsLast90Days: 10,
+          openPrsCount: 5,
+          mergedPrsLast90Days: 0,
+        }),
+      );
+      expect(flags.some((f) => f.severity === "critical")).toBe(true);
+      expect(flags.some((f) => f.severity === "warning")).toBe(true);
+    });
+  });
+
+  describe("severity", () => {
+    it("archived_repository is always critical", () => {
+      const flags = detectRedFlags(makeSnapshot({ isArchived: true }));
+      const flag = flags.find((f) => f.id === "archived_repository");
+      expect(flag?.severity).toBe("critical");
+    });
+
+    it("extended_inactivity is always critical", () => {
+      const flags = detectRedFlags(
+        makeSnapshot({
+          lastCommitAt: daysAgo(200),
+          lastMergedPrAt: null,
+          lastReleaseAt: null,
+        }),
+      );
+      const flag = flags.find((f) => f.id === "extended_inactivity");
+      expect(flag?.severity).toBe("critical");
+    });
+
+    it("stale_pull_requests is critical", () => {
+      const flags = detectRedFlags(
+        makeSnapshot({
+          openPrsCount: 5,
+          mergedPrsLast90Days: 0,
+        }),
+      );
+      const flag = flags.find((f) => f.id === "stale_pull_requests");
+      expect(flag?.severity).toBe("critical");
+    });
+
+    it("remaining contextual flags are warning", () => {
+      const warningIds = [
+        "no_release_despite_commits",
+        "no_issues_activity",
+        "no_releases_ever",
+      ];
+      const flags = detectRedFlags(
+        makeSnapshot({
+          commitsLast90Days: 20,
+          lastReleaseAt: null,
+          releases: [],
+          repositoryCreatedAt: "2020-01-01T00:00:00.000Z",
+          commitsLast365Days: 50,
+          issuesCreatedLastYear: 0,
+          closedIssuesCount: 0,
+          openIssuesCount: 0,
+        }),
+      );
+      for (const id of warningIds) {
+        const flag = flags.find((f) => f.id === id);
+        expect(flag?.severity, `${id} should be warning`).toBe("warning");
+      }
+    });
+  });
+});

--- a/src/core/red-flags/red-flags.test.ts
+++ b/src/core/red-flags/red-flags.test.ts
@@ -247,6 +247,7 @@ describe("detectRedFlags", () => {
           makeSnapshot({
             issuesCreatedLastYear: 0,
             closedIssuesCount: 0,
+            lastClosedIssueAt: null,
             openIssuesCount: 0,
             commitsLast90Days: 10,
           }),
@@ -255,17 +256,32 @@ describe("detectRedFlags", () => {
       ).toBe(true);
     });
 
-    it("does not flag repos with any issue activity", () => {
+    it("does not flag repos with recent issue activity", () => {
       expect(
         hasFlag(
           makeSnapshot({
             issuesCreatedLastYear: 5,
-            closedIssuesCount: 3,
+            lastClosedIssueAt: daysAgo(30),
             openIssuesCount: 2,
           }),
           "no_issues_activity",
         ),
       ).toBe(false);
+    });
+
+    it("flags repos where last closed issue is older than the activity window", () => {
+      expect(
+        hasFlag(
+          makeSnapshot({
+            issuesCreatedLastYear: 0,
+            lastClosedIssueAt: daysAgo(400),
+            closedIssuesCount: 10,
+            openIssuesCount: 0,
+            commitsLast90Days: 10,
+          }),
+          "no_issues_activity",
+        ),
+      ).toBe(true);
     });
 
     it("does not flag inactive repos with no issues", () => {
@@ -427,6 +443,7 @@ describe("detectRedFlags", () => {
           commitsLast365Days: 50,
           issuesCreatedLastYear: 0,
           closedIssuesCount: 0,
+          lastClosedIssueAt: null,
           openIssuesCount: 0,
         }),
       );

--- a/src/core/red-flags/red-flags.ts
+++ b/src/core/red-flags/red-flags.ts
@@ -84,10 +84,18 @@ function checkStalePullRequests(metrics: MetricsSnapshot): RedFlag | null {
   };
 }
 
-function checkNoIssuesActivity(metrics: MetricsSnapshot): RedFlag | null {
+function checkNoIssuesActivity(
+  metrics: MetricsSnapshot,
+  now: Date,
+): RedFlag | null {
+  const daysSinceLastClosed = daysSince(metrics.lastClosedIssueAt, now);
+  const hasRecentClose =
+    daysSinceLastClosed !== null &&
+    daysSinceLastClosed < RED_FLAGS_THRESHOLDS.recentIssueActivityDays;
+
   if (
     metrics.issuesCreatedLastYear > 0 ||
-    metrics.closedIssuesCount > 0 ||
+    hasRecentClose ||
     metrics.openIssuesCount > 0
   )
     return null;
@@ -130,15 +138,16 @@ function checkNoReleasesEver(
   };
 }
 
-export function detectRedFlags(metrics: MetricsSnapshot): RedFlag[] {
-  const now = new Date();
-
+export function detectRedFlags(
+  metrics: MetricsSnapshot,
+  now: Date = new Date(),
+): RedFlag[] {
   return [
     checkArchived(metrics),
     checkExtendedInactivity(metrics, now),
     checkNoReleaseDespiteCommits(metrics, now),
     checkStalePullRequests(metrics),
-    checkNoIssuesActivity(metrics),
+    checkNoIssuesActivity(metrics, now),
     checkNoReleasesEver(metrics, now),
   ].filter((flag): flag is RedFlag => flag !== null);
 }

--- a/src/core/red-flags/red-flags.ts
+++ b/src/core/red-flags/red-flags.ts
@@ -1,0 +1,144 @@
+import type { MetricsSnapshot } from "@/lib/domain/assessment";
+import { RED_FLAGS_THRESHOLDS } from "./red-flags-config";
+import type { RedFlag } from "./types";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function daysSince(dateStr: string | null, now: Date): number | null {
+  if (!dateStr) return null;
+  const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) return null;
+  return Math.floor((now.getTime() - date.getTime()) / DAY_MS);
+}
+
+function checkArchived(metrics: MetricsSnapshot): RedFlag | null {
+  if (!metrics.isArchived) return null;
+  return {
+    id: "archived_repository",
+    severity: "critical",
+    title: "Archived repository",
+    description:
+      "This repository has been archived by its owner and is read-only. No further updates are expected.",
+  };
+}
+
+function checkExtendedInactivity(
+  metrics: MetricsSnapshot,
+  now: Date,
+): RedFlag | null {
+  const activityDays = [
+    daysSince(metrics.lastCommitAt, now),
+    daysSince(metrics.lastMergedPrAt, now),
+    daysSince(metrics.lastReleaseAt, now),
+  ].filter((d): d is number => d !== null);
+
+  if (activityDays.length === 0) return null;
+
+  const mostRecentDays = Math.min(...activityDays);
+  if (mostRecentDays < RED_FLAGS_THRESHOLDS.extendedInactivityDays) return null;
+
+  return {
+    id: "extended_inactivity",
+    severity: "critical",
+    title: "Extended inactivity",
+    description: `No commits, merged pull requests, or releases in over ${RED_FLAGS_THRESHOLDS.extendedInactivityDays} days.`,
+  };
+}
+
+function checkNoReleaseDespiteCommits(
+  metrics: MetricsSnapshot,
+  now: Date,
+): RedFlag | null {
+  if (metrics.commitsLast90Days < RED_FLAGS_THRESHOLDS.activeCommitsThreshold)
+    return null;
+
+  const daysSinceRelease = daysSince(metrics.lastReleaseAt, now);
+
+  // Has a recent release — no flag
+  if (
+    daysSinceRelease !== null &&
+    daysSinceRelease < RED_FLAGS_THRESHOLDS.noRecentReleaseDays
+  )
+    return null;
+
+  // Active commits but no recent release (or no release at all)
+  return {
+    id: "no_release_despite_commits",
+    severity: "warning",
+    title: "No release despite active commits",
+    description:
+      "Commits are being made but no release has been published recently. Changes may not be reaching users.",
+  };
+}
+
+function checkStalePullRequests(metrics: MetricsSnapshot): RedFlag | null {
+  if (metrics.openPrsCount < RED_FLAGS_THRESHOLDS.stalePrsMinOpen) return null;
+  if (metrics.mergedPrsLast90Days > 0) return null;
+
+  return {
+    id: "stale_pull_requests",
+    severity: "critical",
+    title: "Stale pull requests",
+    description:
+      "There are open pull requests but none have been merged in the last 90 days.",
+  };
+}
+
+function checkNoIssuesActivity(metrics: MetricsSnapshot): RedFlag | null {
+  if (
+    metrics.issuesCreatedLastYear > 0 ||
+    metrics.closedIssuesCount > 0 ||
+    metrics.openIssuesCount > 0
+  )
+    return null;
+
+  if (metrics.commitsLast90Days < RED_FLAGS_THRESHOLDS.activeCommitsThreshold)
+    return null;
+
+  return {
+    id: "no_issues_activity",
+    severity: "warning",
+    title: "No issues tracker activity",
+    description:
+      "No issues have been opened or closed despite active development. The issue tracker may not be used for coordination.",
+  };
+}
+
+function checkNoReleasesEver(
+  metrics: MetricsSnapshot,
+  now: Date,
+): RedFlag | null {
+  if (metrics.releases.length > 0) return null;
+
+  const ageDays = daysSince(metrics.repositoryCreatedAt, now);
+  if (ageDays === null) return null;
+
+  const ageYears = ageDays / 365;
+  if (ageYears < RED_FLAGS_THRESHOLDS.noReleasesEverMinAgeYears) return null;
+
+  const commitsLastYear =
+    metrics.commitsLast365Days ?? metrics.commitsLast90Days * 4;
+  if (commitsLastYear < RED_FLAGS_THRESHOLDS.noReleasesEverMinCommits)
+    return null;
+
+  return {
+    id: "no_releases_ever",
+    severity: "warning",
+    title: "No releases published",
+    description:
+      "This repository has never cut a release despite being active for over a year. There may be no formal versioning.",
+  };
+}
+
+export function detectRedFlags(metrics: MetricsSnapshot): RedFlag[] {
+  const now = new Date();
+
+  return [
+    checkArchived(metrics),
+    checkExtendedInactivity(metrics, now),
+    checkNoReleaseDespiteCommits(metrics, now),
+    checkStalePullRequests(metrics),
+    checkNoIssuesActivity(metrics),
+    checkNoReleasesEver(metrics, now),
+  ].filter((flag): flag is RedFlag => flag !== null);
+}

--- a/src/core/red-flags/types.ts
+++ b/src/core/red-flags/types.ts
@@ -1,0 +1,16 @@
+export type RedFlagSeverity = "warning" | "critical";
+
+export type RedFlagId =
+  | "archived_repository"
+  | "extended_inactivity"
+  | "no_release_despite_commits"
+  | "stale_pull_requests"
+  | "no_issues_activity"
+  | "no_releases_ever";
+
+export interface RedFlag {
+  id: RedFlagId;
+  severity: RedFlagSeverity;
+  title: string;
+  description: string;
+}


### PR DESCRIPTION
## Summary

- Add red flags detection system that identifies 6 concerning patterns in repository metrics: archived repo, extended inactivity (180+ days), no release despite active commits, stale PRs (open but none merged in 90 days), no issues tracker activity, and no releases ever published
- Display flags as clickable badges with popovers in the project header, below repository stats
- Detection logic runs server-side as a pure function (`MetricsSnapshot → RedFlag[]`), keeping it out of the client bundle
- Critical flags (archived, inactivity, stale PRs) show in red; warning flags show in amber

## Test plan

- [x] 29 unit tests covering all 6 flags, boundary conditions, severity assignments, and multi-flag scenarios
- [x] `bun run test` — 104/104 passing
- [x] `bun run check-types` — clean
- [x] `bun run lint` — clean
- [x] `bun run build` — successful production build

Closes #88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project pages now show red-flag badges indicating repository health issues (archived, extended inactivity, missing releases despite commits, stale PRs, no issue activity). Badges display severity and reveal explanatory details in a popover when clicked.

* **Tests**
  * Added comprehensive unit tests covering detection scenarios and severity assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->