### PR TITLE
fix: remove "use cache" boundaries causing stale data

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -44,7 +44,6 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
-  cacheComponents: true,
   reactCompiler: true,
   images: {
     remotePatterns: [

--- a/src/app/_components/recent-analyses.tsx
+++ b/src/app/_components/recent-analyses.tsx
@@ -1,6 +1,5 @@
 import { fetchQuery } from "convex/nextjs";
 import { Code2, Star } from "lucide-react";
-import { cacheLife } from "next/cache";
 import Image from "next/image";
 import Link from "next/link";
 import { Container } from "@/components/container";
@@ -44,9 +43,6 @@ function MiniBar({ level, label }: { level: DimensionLevel; label: string }) {
 }
 
 export async function RecentAnalyses() {
-  "use cache";
-  cacheLife("minutes");
-
   const recentRuns = (await fetchQuery(api.analysisRuns.listRecentCompleted, {
     limit: 12,
   })) as AnalysisRun[];

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -1,6 +1,5 @@
 import { fetchQuery } from "convex/nextjs";
 import type { Metadata } from "next";
-import { cacheLife } from "next/cache";
 import { Container } from "@/components/container";
 import type { AnalysisRun } from "@/lib/domain/assessment";
 import { parseProject } from "@/lib/parse-project";
@@ -46,16 +45,13 @@ export async function generateMetadata({
   };
 }
 
-async function CachedComparePage({
+async function CompareContent({
   a,
   b,
 }: {
   a: string | undefined;
   b: string | undefined;
 }) {
-  "use cache";
-  cacheLife("hours");
-
   const parsedA = a ? parseProject(a) : null;
   const parsedB = b ? parseProject(b) : null;
 
@@ -150,5 +146,5 @@ export default async function ComparePage({
   const { a, b } = await searchParams;
   const normA = normalizeSlug(a);
   const normB = normalizeSlug(b);
-  return <CachedComparePage a={normA?.slug} b={normB?.slug} />;
+  return <CompareContent a={normA?.slug} b={normB?.slug} />;
 }

--- a/src/app/p/[owner]/[project]/_components/auto-refresh.tsx
+++ b/src/app/p/[owner]/[project]/_components/auto-refresh.tsx
@@ -33,7 +33,9 @@ export function AutoRefresh({
           toastIdRef.current = toast.loading("Refreshing analysis data...");
         }
       })
-      .catch(() => {});
+      .catch((error) => {
+        console.error("AutoRefresh: triggerRefreshIfStale failed:", error);
+      });
 
     return () => {
       cancelled = true;

--- a/src/app/p/[owner]/[project]/layout.tsx
+++ b/src/app/p/[owner]/[project]/layout.tsx
@@ -1,6 +1,5 @@
 import { fetchQuery } from "convex/nextjs";
 import type { Metadata } from "next";
-import { cacheLife } from "next/cache";
 import { computeDimensions, type DimensionLevel } from "@/core/dimensions";
 import type { AnalysisRun, MetricsSnapshot } from "@/lib/domain/assessment";
 import { getAnalysisTime } from "@/lib/domain/assessment";
@@ -29,10 +28,7 @@ function summarizeDimensions(levels: DimensionLevel[]): string {
   return "needs attention";
 }
 
-async function cachedMetadata(owner: string, project: string) {
-  "use cache";
-  cacheLife("days");
-
+async function getMetadata(owner: string, project: string) {
   const run = (await fetchQuery(api.analysisRuns.getByRepositorySlug, {
     owner,
     project,
@@ -76,10 +72,7 @@ async function cachedMetadata(owner: string, project: string) {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { owner, project } = await params;
-  const { title, description, canonical } = await cachedMetadata(
-    owner,
-    project,
-  );
+  const { title, description, canonical } = await getMetadata(owner, project);
 
   return {
     title,

--- a/src/app/p/[owner]/[project]/page.tsx
+++ b/src/app/p/[owner]/[project]/page.tsx
@@ -1,5 +1,4 @@
 import { fetchQuery } from "convex/nextjs";
-import { cacheLife } from "next/cache";
 import type { AnalysisRun } from "@/lib/domain/assessment";
 import { api } from "../../../../../convex/_generated/api";
 import { AutoRefresh } from "./_components/auto-refresh";
@@ -11,16 +10,13 @@ import { ReadmeSection } from "./_components/readme-section";
 import { RecentActivity } from "./_components/recent-activity";
 import { ReleaseCadenceSection } from "./_components/release-cadence-section";
 
-async function CachedProjectPage({
+async function ProjectContent({
   owner,
   project,
 }: {
   owner: string;
   project: string;
 }) {
-  "use cache";
-  cacheLife("days");
-
   const run = await fetchQuery(api.analysisRuns.getByRepositorySlug, {
     owner,
     project,
@@ -57,7 +53,7 @@ export default async function ProjectPage({
   return (
     <>
       <AutoRefresh owner={owner} project={project} />
-      <CachedProjectPage owner={owner} project={project} />
+      <ProjectContent owner={owner} project={project} />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Remove all `"use cache"` directives and `cacheLife()` calls that froze RSC output for hours/days with no invalidation, causing visitors to see stale analysis data
- Remove `cacheComponents: true` from Next.js config (no longer needed)
- Fix silent error swallowing in AutoRefresh `.catch(() => {})` — now logs to console

## Test plan
- [ ] `bun run check-types` passes
- [ ] `bun run build` succeeds
- [ ] `bun run lint` clean
- [ ] `bun run test` — all 149 tests pass
- [ ] Visit a project page, verify data matches Convex dashboard
- [ ] Click a recent analysis card from homepage — navigation feels instant (no skeleton flash)
- [ ] Search for a project from homepage — skeletons show briefly, then fresh data
- [ ] Return to a previously visited project — data is fresh, not stale

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging for failed refresh operations to better track issues.

* **Chores**
  * Disabled internal caching configurations to simplify data-fetching behavior across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->